### PR TITLE
New GitHub Action workflow for PRs and updated environment variable setting in the GA

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+    PACKAGE_PREFIX: 1
+    OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
+    OCTOPUS_SPACE_NAME: "Octopus Server"
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        
+      - name: Install Pester
+        id: install-pester
+        run: Install-Module "Pester" -Force
+        shell: pwsh
+       
+      - name: Run Pester Tests
+        id: pester-tests
+        run: |
+          Import-Module -Name "Pester"
+          $configuration = [PesterConfiguration]::Default
+          $configuration.Run.Exit = $true
+          Invoke-Pester -configuration $configuration
+        shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -1,28 +1,17 @@
-# This is a basic workflow to help you get started with Actions
+# Action that is used for PRs to main branch
+# It installs pester and runs the pester tests only
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
 on:
   pull_request:
     branches: [ main ]
-
-env:
-    PACKAGE_PREFIX: 1
-    OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
-    OCTOPUS_SPACE_NAME: "Octopus Server"
     
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         
       - name: Install Pester

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Set version
         id: set-version
-        run: echo "::set-env name=PACKAGE_VERSION::$PACKAGE_PREFIX.$GITHUB_RUN_NUMBER"
+        run: echo "PACKAGE_VERSION=$PACKAGE_PREFIX.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
     
       - name: Make package directories
         run: mkdir -p ./packagesoutput/$OCTOPUS_PACKAGE_NAME    

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -7,8 +7,6 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 env:
     PACKAGE_PREFIX: 1

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -1,9 +1,9 @@
-# This is a basic workflow to help you get started with Actions
+# Action for pushes to main branch
+# It installs pester, runs the pester tests
+# packages the script up and sends it to deploy.octopus.app
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
 on:
   push:
     branches: [ main ]
@@ -13,16 +13,11 @@ env:
     OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
     OCTOPUS_SPACE_NAME: "Octopus Server"
     
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         
       - name: Install Pester


### PR DESCRIPTION
Created a new GitHub Actions workflow for pull requests to main branch to build/test but not package and push to octopus. I realised we were pushing WIP packages to octopus and someone could easily come along and publish a new runbook with a WIP Enthusiastic Promotions script. 

Also updated the way that we set the environment variables. There was a security vunlerability with the old way (read some of it https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and updated to the suggested way to set environment variables  (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)