### PR TITLE
Retry getting Active Problems when Octofront is down

### DIFF
--- a/enthusiastic-promoter.ps1
+++ b/enthusiastic-promoter.ps1
@@ -12,48 +12,75 @@ $waitTimeForEnvironmentLookup = @{
     "Environments-2589" = @{ "Name" = "General Availablilty";       "BakeTime" = New-TimeSpan -Minutes 0; "StabilizationPhaseBakeTime" = New-TimeSpan -Minutes 0; }
 }
 
-function Test-PipelineBlocked($release) {
-    $attempts = 0
-    $maxAttempts = 5
-    do {
-        Write-Host "Attempt $attempts to get active problems for release $($release.Release.Version)"
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [scriptblock]$ScriptBlock,
+        [int]$MaxRetries = 10,
+        [int]$InitialBackoffInMs = 500
+    )
+
+    $backoff = $InitialBackoffInMs
+    $retrycount = -1
+    $returnvalue = $null
+    $success = $false;
+
+    Write-Host "MaxRetries: $MaxRetries"
+    Write-Host "InitialBackoffInMs: $InitialBackoffInMs"
+
+    while($success -eq $false) {
         try {
-            $activeProblems = Test-GetActiveProblems($release)
-            return $activeProblems.Count -gt 0
+            $retrycount++
+            $success = $true;
+            $returnvalue = Invoke-Command $ScriptBlock
         }
-        catch {
-            Write-Warning $_.Exception.Message
-        }
-        $attempts++
-
-        if($attempts -lt $maxAttempts)
+        catch
         {
-            $sleepTime = Get-SleepTime($attempts)
-            Write-Host "Sleeping for $sleepTime seconds before attempting to check active problems again"
-            Start-Sleep -Seconds $sleepTime
+            $success = $false;
+            $message = If ($null -ne $_.Exception) { $_.Exception.ToString() } Else { $error | Select-Object -first 1 }
+            Write-Host "Command failed: $message"
+
+            if (
+                    ($null -ne $_.Exception) -and
+                    ([bool]($_.Exception.PSobject.Properties.name -match "Response")) -and
+                    ($null -ne $_.Exception.Response)
+                ) {
+                $result = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($result)
+                $reader.BaseStream.Position = 0
+                $reader.DiscardBufferedData()
+                $responseBody = $reader.ReadToEnd();
+                Write-Host $responseBody
+            }
+
+            if($retrycount -eq $MaxRetries)
+            {
+                Write-Host "All $retrycount retires have failed."
+                throw $_;
+            }
+
+            $backoff = $backoff + $backoff
+            Write-Host "Invoking a backoff: $backoff [ms]. We have tried $retrycount times"
+            Start-Sleep -MilliSeconds $backoff
         }
-    } while($attempts -lt $maxAttempts)
-    throw "Failed to check active problems for release $($release.Release.Version)"
+    }
+
+    return $returnvalue
 }
 
-function Test-GetActiveProblems($release)
-{
-    $url = "$octofrontUrl/api/Problem/ActiveProblems/OctopusServer/$($release.Release.Version)"
-    Write-Verbose "Getting response from $url"
-    $activeProblems =  (Invoke-restmethod -Uri $url -Headers @{ 'Authorization' = "Bearer $($octofrontApiKey)"}).ActiveProblems
+function Test-PipelineBlocked($release) {
+    Invoke-WithRetry -ScriptBlock {
+        $url = "$octofrontUrl/api/Problem/ActiveProblems/OctopusServer/$($release.Release.Version)"
+        Write-Verbose "Getting response from $url"
+        $activeProblems =  (Invoke-restmethod -Uri $url -Headers @{ 'Authorization' = "Bearer $($octofrontApiKey)"}).ActiveProblems
 
-    # log out the  json, so we can diagnose what's happening / write a test for it
-    write-verbose "--------------------------------------------------------"
-    write-verbose "response:"
-    write-verbose "--------------------------------------------------------"
-    write-verbose ($activeProblems | ConvertTo-Json -depth 10)
-    write-verbose "--------------------------------------------------------"
-}
-
-# Put in method to mock in tests
-function Get-SleepTime($attemptNumber)
-{
-    return 10 * $attemptNumber
+        # log out the  json, so we can diagnose what's happening / write a test for it
+        write-verbose "--------------------------------------------------------"
+        write-verbose "response:"
+        write-verbose "--------------------------------------------------------"
+        write-verbose ($activeProblems | ConvertTo-Json -depth 10)
+        write-verbose "--------------------------------------------------------"
+    }
 }
 
 function Get-CurrentEnvironment($progression, $release) {

--- a/enthusiastic-promotor.tests.ps1
+++ b/enthusiastic-promotor.tests.ps1
@@ -181,7 +181,7 @@ Describe 'Enthusiastic promoter' {
     ($result.Count -gt 0) | should -be $shouldPromote
   }
 
-  It 'should throw when octofront is down' {
+  It 'should retry when octofront is unavailable' {
 
     $script:mockHasMockedOctofrontBeingDown = $false
 

--- a/enthusiastic-promotor.tests.ps1
+++ b/enthusiastic-promotor.tests.ps1
@@ -20,166 +20,166 @@ Describe 'Enthusiastic promoter' {
     . (Join-Path -Path $PSScriptRoot -ChildPath "enthusiastic-promoter.ps1")
   }
 
-  # It 'scenario 1' {
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample1.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  It 'scenario 1' {
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample1.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 4
+    $result.Count | should -be 4
 
-  #   $result[0].Version | Should -be "2020.4.7"
-  #   $result[0].EnvironmentName | Should -be "Stable"
-  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+    $result[0].Version | Should -be "2020.4.7"
+    $result[0].EnvironmentName | Should -be "Stable"
+    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
 
-  #   $result[1].Version | Should -be "2020.5.0-ci0986"
-  #   $result[1].EnvironmentName | Should -be "Staff"
-  #   $result[1].ChannelName | Should -be "CI Builds"
+    $result[1].Version | Should -be "2020.5.0-ci0986"
+    $result[1].EnvironmentName | Should -be "Staff"
+    $result[1].ChannelName | Should -be "CI Builds"
 
-  #   $result[2].Version | Should -be "2020.5.0-rc0002"
-  #   $result[2].EnvironmentName | Should -be "Octopus Cloud Tests"
-  #   $result[2].ChannelName | Should -be "Latest Release - 2020.5"
+    $result[2].Version | Should -be "2020.5.0-rc0002"
+    $result[2].EnvironmentName | Should -be "Octopus Cloud Tests"
+    $result[2].ChannelName | Should -be "Latest Release - 2020.5"
 
-  #   $result[3].Version | Should -be "2020.6.0-ci0003"
-  #   $result[3].EnvironmentName | Should -be "Octopus Cloud Tests"
-  #   $result[3].ChannelName | Should -be "CI Builds"
-  # }
+    $result[3].Version | Should -be "2020.6.0-ci0003"
+    $result[3].EnvironmentName | Should -be "Octopus Cloud Tests"
+    $result[3].ChannelName | Should -be "CI Builds"
+  }
 
-  # It 'should only promote 2020.4.7' {
-  #   # everything else is either:
-  #   # * baking
-  #   # * progressed as far as it can
-  #   # * had a deployment attempted, but it failed
-  #   # * had a deployment attempted - its still executing or queued
+  It 'should only promote 2020.4.7' {
+    # everything else is either:
+    # * baking
+    # * progressed as far as it can
+    # * had a deployment attempted, but it failed
+    # * had a deployment attempted - its still executing or queued
 
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample2.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample2.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | Should -be 1
+    $result.Count | Should -be 1
 
-  #   $result[0].Version | Should -be "2020.4.7"
-  #   $result[0].EnvironmentName | Should -be "Stable"
-  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
-  # }
+    $result[0].Version | Should -be "2020.4.7"
+    $result[0].EnvironmentName | Should -be "Stable"
+    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+  }
 
-  # It 'should promote 2020.6.0-ci0003 as it is the latest in the CI Builds channel' {
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
-  #   $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  It 'should promote 2020.6.0-ci0003 as it is the latest in the CI Builds channel' {
+    Mock Test-PipelineBlocked { return $false; }
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+    $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 2
+    $result.Count | should -be 2
 
-  #   $result[0].Version | Should -be "2020.4.7"
-  #   $result[0].EnvironmentName | Should -be "Stable"
-  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+    $result[0].Version | Should -be "2020.4.7"
+    $result[0].EnvironmentName | Should -be "Stable"
+    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
 
-  #   # 2020.6.0-ci0026 is still baking
+    # 2020.6.0-ci0026 is still baking
 
-  #   $result[1].Version | Should -be "2020.6.0-ci0003"
-  #   $result[1].EnvironmentName | Should -be "Octopus Cloud Tests"
-  #   $result[1].ChannelName | Should -be "CI Builds"
-  # }
+    $result[1].Version | Should -be "2020.6.0-ci0003"
+    $result[1].EnvironmentName | Should -be "Octopus Cloud Tests"
+    $result[1].ChannelName | Should -be "CI Builds"
+  }
 
-  # It 'should not promote 2020.6.0-ci0002 as a newer release (2020.6.0-ci0003) has already been promoted to the Octopus Cloud Tests environment' {
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample4.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  It 'should not promote 2020.6.0-ci0002 as a newer release (2020.6.0-ci0003) has already been promoted to the Octopus Cloud Tests environment' {
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample4.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 0
-  # }
+    $result.Count | should -be 0
+  }
 
-  # It 'should choose the stabilisation phase for channels using the Current Release (prior to going GA) lifecycle' {
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  It 'should choose the stabilisation phase for channels using the Current Release (prior to going GA) lifecycle' {
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
 
-  #   $channelId = "Channels-4583" #'Latest Release - 2020.5', uses lifecycle Lifecycles-1667 'Current Release (prior to going GA)'
-  #   $result = Test-ReleaseInStabilizationPhase $channelId $channels
-  #   $result | Should -be $true
+    $channelId = "Channels-4583" #'Latest Release - 2020.5', uses lifecycle Lifecycles-1667 'Current Release (prior to going GA)'
+    $result = Test-ReleaseInStabilizationPhase $channelId $channels
+    $result | Should -be $true
 
-  #   $channelId = "Channels-4449" #'Previous Release - 2020.4', uses lifecycle Lifecycles-1669 'Previous Release (prior to new release going GA)'
-  #   $result = Test-ReleaseInStabilizationPhase $channelId $channels
-  #   $result | Should -be $false
-  # }
+    $channelId = "Channels-4449" #'Previous Release - 2020.4', uses lifecycle Lifecycles-1669 'Previous Release (prior to new release going GA)'
+    $result = Test-ReleaseInStabilizationPhase $channelId $channels
+    $result | Should -be $false
+  }
 
-  # It 'should handle a modified lifecycle where an earlier phase is added' {
-  #   # when an earlier phase is added, it means there are two candidates for deployment
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample5-modifiedlifecycle.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  It 'should handle a modified lifecycle where an earlier phase is added' {
+    # when an earlier phase is added, it means there are two candidates for deployment
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample5-modifiedlifecycle.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 0
-  # }
+    $result.Count | should -be 0
+  }
 
-  # It 'should handle a release that has not yet been deployed to the initial environment (for as single release) ' {
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample5-release-created-but-no-deployments.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("01/Nov/2020 8:52:17 AM") }
+  It 'should handle a release that has not yet been deployed to the initial environment (for as single release) ' {
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample5-release-created-but-no-deployments.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("01/Nov/2020 8:52:17 AM") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 0
-  # }
+    $result.Count | should -be 0
+  }
 
-  # It 'should handle a release that has not yet been deployed to the initial environment (with multiple releases)' {
-  #   Mock Test-PipelineBlocked { return $false; }
-  #   $progression = (Get-Content -Path "SampleData/sample6.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("05/Feb/2021 1:08:20 AM") }
+  It 'should handle a release that has not yet been deployed to the initial environment (with multiple releases)' {
+    Mock Test-PipelineBlocked { return $false; }
+    $progression = (Get-Content -Path "SampleData/sample6.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("05/Feb/2021 1:08:20 AM") }
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   $result.Count | should -be 1
+    $result.Count | should -be 1
 
-  #   $result[0].Version | Should -be "2020.5.9"
-  #   $result[0].EnvironmentName | Should -be "Production"
-  #   $result[0].ChannelName | Should -be "Latest Release - 2020.5"
-  # }
+    $result[0].Version | Should -be "2020.5.9"
+    $result[0].EnvironmentName | Should -be "Production"
+    $result[0].ChannelName | Should -be "Latest Release - 2020.5"
+  }
 
-  # It 'should not promote during weekend period' -TestCases @( # All written in AEST times
-  #   @{ datetime = '20/Nov/2020 16:00:00'; shouldPromote = $false} #Friday 4pm
-  #   @{ datetime = '20/Nov/2020 15:59:59'; shouldPromote = $true} #Friday 3:59pm
-  #   @{ datetime = '21/Nov/2020 00:00:00'; shouldPromote = $false} #Saturday
-  #   @{ datetime = '22/Nov/2020 00:00:00'; shouldPromote = $false} #Sunday
-  #   @{ datetime = '23/Nov/2020 07:59:59'; shouldPromote = $false} #Monday 7:59am
-  #   @{ datetime = '23/Nov/2020 08:00:00'; shouldPromote = $true} #Monday 8:00am
-  # ) {
-  #   param
-  #   (
-  #     [string] $dateTime,
-  #     [boolean] $shouldPromote
-  #   )
+  It 'should not promote during weekend period' -TestCases @( # All written in AEST times
+    @{ datetime = '20/Nov/2020 16:00:00'; shouldPromote = $false} #Friday 4pm
+    @{ datetime = '20/Nov/2020 15:59:59'; shouldPromote = $true} #Friday 3:59pm
+    @{ datetime = '21/Nov/2020 00:00:00'; shouldPromote = $false} #Saturday
+    @{ datetime = '22/Nov/2020 00:00:00'; shouldPromote = $false} #Sunday
+    @{ datetime = '23/Nov/2020 07:59:59'; shouldPromote = $false} #Monday 7:59am
+    @{ datetime = '23/Nov/2020 08:00:00'; shouldPromote = $true} #Monday 8:00am
+  ) {
+    param
+    (
+      [string] $dateTime,
+      [boolean] $shouldPromote
+    )
 
-  #   $timezone = "E. Australia Standard Time";
-  #   if($IsLinux) {
-  #     $timezone = "Australia/Brisbane"
-  #   }
+    $timezone = "E. Australia Standard Time";
+    if($IsLinux) {
+      $timezone = "Australia/Brisbane"
+    }
 
-  #   Mock Test-PipelineBlocked { $false }
-  #   Mock Get-CurrentTimezone { return Get-TimeZone -Id $timezone }
-  #   Mock Get-CurrentDate { return [System.DateTime]::Parse($dateTime) }
+    Mock Test-PipelineBlocked { $false }
+    Mock Get-CurrentTimezone { return Get-TimeZone -Id $timezone }
+    Mock Get-CurrentDate { return [System.DateTime]::Parse($dateTime) }
 
-  #   $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
-  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+    $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
 
-  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-  #   ($result.Count -gt 0) | should -be $shouldPromote
-  # }
+    ($result.Count -gt 0) | should -be $shouldPromote
+  }
 
   It 'should throw when octofront is down' {
 

--- a/enthusiastic-promotor.tests.ps1
+++ b/enthusiastic-promotor.tests.ps1
@@ -20,165 +20,188 @@ Describe 'Enthusiastic promoter' {
     . (Join-Path -Path $PSScriptRoot -ChildPath "enthusiastic-promoter.ps1")
   }
 
-  It 'scenario 1' {
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample1.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  # It 'scenario 1' {
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample1.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 4
+  #   $result.Count | should -be 4
 
-    $result[0].Version | Should -be "2020.4.7"
-    $result[0].EnvironmentName | Should -be "Stable"
-    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+  #   $result[0].Version | Should -be "2020.4.7"
+  #   $result[0].EnvironmentName | Should -be "Stable"
+  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
 
-    $result[1].Version | Should -be "2020.5.0-ci0986"
-    $result[1].EnvironmentName | Should -be "Staff"
-    $result[1].ChannelName | Should -be "CI Builds"
+  #   $result[1].Version | Should -be "2020.5.0-ci0986"
+  #   $result[1].EnvironmentName | Should -be "Staff"
+  #   $result[1].ChannelName | Should -be "CI Builds"
 
-    $result[2].Version | Should -be "2020.5.0-rc0002"
-    $result[2].EnvironmentName | Should -be "Octopus Cloud Tests"
-    $result[2].ChannelName | Should -be "Latest Release - 2020.5"
+  #   $result[2].Version | Should -be "2020.5.0-rc0002"
+  #   $result[2].EnvironmentName | Should -be "Octopus Cloud Tests"
+  #   $result[2].ChannelName | Should -be "Latest Release - 2020.5"
 
-    $result[3].Version | Should -be "2020.6.0-ci0003"
-    $result[3].EnvironmentName | Should -be "Octopus Cloud Tests"
-    $result[3].ChannelName | Should -be "CI Builds"
-  }
+  #   $result[3].Version | Should -be "2020.6.0-ci0003"
+  #   $result[3].EnvironmentName | Should -be "Octopus Cloud Tests"
+  #   $result[3].ChannelName | Should -be "CI Builds"
+  # }
 
-  It 'should only promote 2020.4.7' {
-    # everything else is either:
-    # * baking
-    # * progressed as far as it can
-    # * had a deployment attempted, but it failed
-    # * had a deployment attempted - its still executing or queued
+  # It 'should only promote 2020.4.7' {
+  #   # everything else is either:
+  #   # * baking
+  #   # * progressed as far as it can
+  #   # * had a deployment attempted, but it failed
+  #   # * had a deployment attempted - its still executing or queued
 
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample2.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample2.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | Should -be 1
+  #   $result.Count | Should -be 1
 
-    $result[0].Version | Should -be "2020.4.7"
-    $result[0].EnvironmentName | Should -be "Stable"
-    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
-  }
+  #   $result[0].Version | Should -be "2020.4.7"
+  #   $result[0].EnvironmentName | Should -be "Stable"
+  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+  # }
 
-  It 'should promote 2020.6.0-ci0003 as it is the latest in the CI Builds channel' {
-    Mock Test-PipelineBlocked { return $false; }
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
-    $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  # It 'should promote 2020.6.0-ci0003 as it is the latest in the CI Builds channel' {
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  #   $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 2
+  #   $result.Count | should -be 2
 
-    $result[0].Version | Should -be "2020.4.7"
-    $result[0].EnvironmentName | Should -be "Stable"
-    $result[0].ChannelName | Should -be "Previous Release - 2020.4"
+  #   $result[0].Version | Should -be "2020.4.7"
+  #   $result[0].EnvironmentName | Should -be "Stable"
+  #   $result[0].ChannelName | Should -be "Previous Release - 2020.4"
 
-    # 2020.6.0-ci0026 is still baking
+  #   # 2020.6.0-ci0026 is still baking
 
-    $result[1].Version | Should -be "2020.6.0-ci0003"
-    $result[1].EnvironmentName | Should -be "Octopus Cloud Tests"
-    $result[1].ChannelName | Should -be "CI Builds"
-  }
+  #   $result[1].Version | Should -be "2020.6.0-ci0003"
+  #   $result[1].EnvironmentName | Should -be "Octopus Cloud Tests"
+  #   $result[1].ChannelName | Should -be "CI Builds"
+  # }
 
-  It 'should not promote 2020.6.0-ci0002 as a newer release (2020.6.0-ci0003) has already been promoted to the Octopus Cloud Tests environment' {
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample4.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  # It 'should not promote 2020.6.0-ci0002 as a newer release (2020.6.0-ci0003) has already been promoted to the Octopus Cloud Tests environment' {
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample4.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 0
-  }
+  #   $result.Count | should -be 0
+  # }
 
-  It 'should choose the stabilisation phase for channels using the Current Release (prior to going GA) lifecycle' {
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  # It 'should choose the stabilisation phase for channels using the Current Release (prior to going GA) lifecycle' {
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
 
-    $channelId = "Channels-4583" #'Latest Release - 2020.5', uses lifecycle Lifecycles-1667 'Current Release (prior to going GA)'
-    $result = Test-ReleaseInStabilizationPhase $channelId $channels
-    $result | Should -be $true
+  #   $channelId = "Channels-4583" #'Latest Release - 2020.5', uses lifecycle Lifecycles-1667 'Current Release (prior to going GA)'
+  #   $result = Test-ReleaseInStabilizationPhase $channelId $channels
+  #   $result | Should -be $true
 
-    $channelId = "Channels-4449" #'Previous Release - 2020.4', uses lifecycle Lifecycles-1669 'Previous Release (prior to new release going GA)'
-    $result = Test-ReleaseInStabilizationPhase $channelId $channels
-    $result | Should -be $false
-  }
+  #   $channelId = "Channels-4449" #'Previous Release - 2020.4', uses lifecycle Lifecycles-1669 'Previous Release (prior to new release going GA)'
+  #   $result = Test-ReleaseInStabilizationPhase $channelId $channels
+  #   $result | Should -be $false
+  # }
 
-  It 'should handle a modified lifecycle where an earlier phase is added' {
-    # when an earlier phase is added, it means there are two candidates for deployment
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample5-modifiedlifecycle.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
+  # It 'should handle a modified lifecycle where an earlier phase is added' {
+  #   # when an earlier phase is added, it means there are two candidates for deployment
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample5-modifiedlifecycle.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("19/Oct/2020 15:35:06") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 0
-  }
+  #   $result.Count | should -be 0
+  # }
 
-  It 'should handle a release that has not yet been deployed to the initial environment (for as single release) ' {
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample5-release-created-but-no-deployments.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("01/Nov/2020 8:52:17 AM") }
+  # It 'should handle a release that has not yet been deployed to the initial environment (for as single release) ' {
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample5-release-created-but-no-deployments.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("01/Nov/2020 8:52:17 AM") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 0
-  }
+  #   $result.Count | should -be 0
+  # }
 
-  It 'should handle a release that has not yet been deployed to the initial environment (with multiple releases)' {
-    Mock Test-PipelineBlocked { return $false; }
-    $progression = (Get-Content -Path "SampleData/sample6.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-    Mock Get-CurrentDate { return [System.DateTime]::Parse("05/Feb/2021 1:08:20 AM") }
+  # It 'should handle a release that has not yet been deployed to the initial environment (with multiple releases)' {
+  #   Mock Test-PipelineBlocked { return $false; }
+  #   $progression = (Get-Content -Path "SampleData/sample6.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse("05/Feb/2021 1:08:20 AM") }
 
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
 
-    $result.Count | should -be 1
+  #   $result.Count | should -be 1
 
-    $result[0].Version | Should -be "2020.5.9"
-    $result[0].EnvironmentName | Should -be "Production"
-    $result[0].ChannelName | Should -be "Latest Release - 2020.5"
-  }
+  #   $result[0].Version | Should -be "2020.5.9"
+  #   $result[0].EnvironmentName | Should -be "Production"
+  #   $result[0].ChannelName | Should -be "Latest Release - 2020.5"
+  # }
 
-  It 'should not promote during weekend period' -TestCases @( # All written in AEST times
-    @{ datetime = '20/Nov/2020 16:00:00'; shouldPromote = $false} #Friday 4pm
-    @{ datetime = '20/Nov/2020 15:59:59'; shouldPromote = $true} #Friday 3:59pm
-    @{ datetime = '21/Nov/2020 00:00:00'; shouldPromote = $false} #Saturday
-    @{ datetime = '22/Nov/2020 00:00:00'; shouldPromote = $false} #Sunday
-    @{ datetime = '23/Nov/2020 07:59:59'; shouldPromote = $false} #Monday 7:59am
-    @{ datetime = '23/Nov/2020 08:00:00'; shouldPromote = $true} #Monday 8:00am
-  ) {
-    param
-    (
-      [string] $dateTime,
-      [boolean] $shouldPromote
-    )
+  # It 'should not promote during weekend period' -TestCases @( # All written in AEST times
+  #   @{ datetime = '20/Nov/2020 16:00:00'; shouldPromote = $false} #Friday 4pm
+  #   @{ datetime = '20/Nov/2020 15:59:59'; shouldPromote = $true} #Friday 3:59pm
+  #   @{ datetime = '21/Nov/2020 00:00:00'; shouldPromote = $false} #Saturday
+  #   @{ datetime = '22/Nov/2020 00:00:00'; shouldPromote = $false} #Sunday
+  #   @{ datetime = '23/Nov/2020 07:59:59'; shouldPromote = $false} #Monday 7:59am
+  #   @{ datetime = '23/Nov/2020 08:00:00'; shouldPromote = $true} #Monday 8:00am
+  # ) {
+  #   param
+  #   (
+  #     [string] $dateTime,
+  #     [boolean] $shouldPromote
+  #   )
 
-    $timezone = "E. Australia Standard Time";
-    if($IsLinux) {
-      $timezone = "Australia/Brisbane"
+  #   $timezone = "E. Australia Standard Time";
+  #   if($IsLinux) {
+  #     $timezone = "Australia/Brisbane"
+  #   }
+
+  #   Mock Test-PipelineBlocked { $false }
+  #   Mock Get-CurrentTimezone { return Get-TimeZone -Id $timezone }
+  #   Mock Get-CurrentDate { return [System.DateTime]::Parse($dateTime) }
+
+  #   $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
+  #   $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
+
+  #   $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+
+  #   ($result.Count -gt 0) | should -be $shouldPromote
+  # }
+
+  It 'should throw when octofront is down' {
+
+    $script:mockHasMockedOctofrontBeingDown = $false
+
+    Mock Get-SleepTime { return 0 }
+    Mock Test-GetActiveProblems {
+      if($global:mockHasMockedOctofrontBeingDown -eq $false) {
+        $global:mockHasMockedOctofrontBeingDown = $true
+        throw "Error"
+      }
+
+      return {
+        ActiveProblems: [{}]
+      }
     }
+    Mock Write-Warning {}
 
-    Mock Test-PipelineBlocked { $false }
-    Mock Get-CurrentTimezone { return Get-TimeZone -Id $timezone }
-    Mock Get-CurrentDate { return [System.DateTime]::Parse($dateTime) }
+    $progression = (Get-Content -Path "SampleData/sample6.json" -Raw) | ConvertFrom-Json
+    $release = $progression.Releases[0]
 
-    $progression = (Get-Content -Path "SampleData/sample3.json" -Raw) | ConvertFrom-Json
-    $channels = (Get-Content -Path "SampleData/channels.json" -Raw) | ConvertFrom-Json
-
-    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
-
-    ($result.Count -gt 0) | should -be $shouldPromote
-
+    Test-PipelineBlocked($release) | Should -be 1
+    Assert-MockCalled Write-Warning -Times 1
   }
 }


### PR DESCRIPTION
Now we're using the Production server again, it's more likely we're going to run into Octofront being down when trying to check for Active Problems.

This wraps a retry around it and creates a test to check the retry behaviour. 