### PR TITLE
Auto Publish Runbook from Action

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -36,5 +36,5 @@ jobs:
         shell: pwsh
 
       - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL="${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey="${{ secrets.OCTOPUS_APIKEY }}" -spaceName="$OCTOPUS_SPACE_NAME" -projectName="$OCTOPUS_PROJECT_NAME" -runbookName="$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
         shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -11,8 +11,6 @@ env:
     PACKAGE_PREFIX: 1
     OCTOPUS_PACKAGE_NAME: "EnthisuasticPromotions"
     OCTOPUS_SPACE_NAME: "Octopus Server"
-    OCTOPUS_PROJECT_NAME: "Octopus Server"
-    OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
 
 jobs:
   build:
@@ -33,8 +31,4 @@ jobs:
           $configuration = [PesterConfiguration]::Default
           $configuration.Run.Exit = $true
           Invoke-Pester -configuration $configuration
-        shell: pwsh
-
-      - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
         shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches: [ main ]
     
+env:
+    PACKAGE_PREFIX: 1
+    OCTOPUS_PACKAGE_NAME: "EnthisuasticPromotions"
+    OCTOPUS_SPACE_NAME: "Octopus Server"
+    OCTOPUS_PROJECT_NAME: "Octopus Server"
+    OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,4 +33,8 @@ jobs:
           $configuration = [PesterConfiguration]::Default
           $configuration.Run.Exit = $true
           Invoke-Pester -configuration $configuration
+        shell: pwsh
+
+      - name: Publish Runbook
+        run: ./Build/UpdateRunbook.ps1 -octopusURL="${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey="${{ secrets.OCTOPUS_APIKEY }}" -spaceName="$OCTOPUS_SPACE_NAME" -projectName="$OCTOPUS_PROJECT_NAME" -runbookName="$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
         shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -13,7 +13,7 @@ env:
     OCTOPUS_SPACE_NAME: "Octopus Server"
     OCTOPUS_PROJECT_NAME: "Octopus Server"
     OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }} " -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }}" -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
         shell: pwsh
         
       - name: Install Pester

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -7,12 +7,23 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+    PACKAGE_PREFIX: 1
+    OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
+    OCTOPUS_SPACE_NAME: "Octopus Server"
+    OCTOPUS_PROJECT_NAME: "Octopus Server"
+    OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
+    
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Publish Runbook
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }} " -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
+        shell: pwsh
         
       - name: Install Pester
         id: install-pester

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -6,11 +6,6 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
-    
-env:
-    PACKAGE_PREFIX: 1
-    OCTOPUS_PACKAGE_NAME: "EnthisuasticPromotions"
-    OCTOPUS_SPACE_NAME: "Octopus Server"
 
 jobs:
   build:

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -7,23 +7,12 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-    PACKAGE_PREFIX: 1
-    OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
-    OCTOPUS_SPACE_NAME: "Octopus Server"
-    OCTOPUS_PROJECT_NAME: "Octopus Server"
-    OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }}" -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
-        shell: pwsh
         
       - name: Install Pester
         id: install-pester

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -59,3 +59,7 @@ jobs:
           
       - name: Push to Octopus
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
+
+      - name: Publish Runbook
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }}" -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
+        shell: pwsh

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -61,5 +61,10 @@ jobs:
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
 
       - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName $OCTOPUS_SPACE_NAME -projectName $OCTOPUS_PROJECT_NAME -runbookName $OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME
+        run: | 
+          Write-Host "Package name: $OCTOPUS_PACKAGE_NAME"
+          Write-Host "Package name env: ${{ env.OCTOPUS_PACKAGE_NAME }}"
+          Write-Host "Space name: $OCTOPUS_SPACE_NAME"
+          Write-Host "Space name env: ${{ env.OCTOPUS_SPACE_NAME }}"
+          ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
         shell: pwsh

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -6,7 +6,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, enh-auto-publish-runbook]
+    branches: [ main ]
 
 env:
     PACKAGE_PREFIX: 1
@@ -59,7 +59,3 @@ jobs:
           
       - name: Push to Octopus
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
-
-      - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }} " -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
-        shell: pwsh

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -61,10 +61,5 @@ jobs:
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
 
       - name: Publish Runbook
-        run: | 
-          Write-Host "Package name: $OCTOPUS_PACKAGE_NAME"
-          Write-Host "Package name env: ${{ env.OCTOPUS_PACKAGE_NAME }}"
-          Write-Host "Space name: $OCTOPUS_SPACE_NAME"
-          Write-Host "Space name env: ${{ env.OCTOPUS_SPACE_NAME }}"
-          ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }} " -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"
         shell: pwsh

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -6,12 +6,14 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, enh-auto-publish-runbook]
 
 env:
     PACKAGE_PREFIX: 1
     OCTOPUS_PACKAGE_NAME: EnthisuasticPromotions
     OCTOPUS_SPACE_NAME: "Octopus Server"
+    OCTOPUS_PROJECT_NAME: "Octopus Server"
+    OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME: "Enthusiastic Promotions"
     
 jobs:
   build:
@@ -57,3 +59,7 @@ jobs:
           
       - name: Push to Octopus
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
+
+      - name: Publish Runbook
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
+        shell: pwsh

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -61,5 +61,5 @@ jobs:
         run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
 
       - name: Publish Runbook
-        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "$OCTOPUS_SPACE_NAME" -projectName "$OCTOPUS_PROJECT_NAME" -runbookName "$OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME"
+        run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName $OCTOPUS_SPACE_NAME -projectName $OCTOPUS_PROJECT_NAME -runbookName $OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME
         shell: pwsh

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -1,0 +1,65 @@
+param (
+    [string]$octopusURL,
+    [string]$octopusAPIKey,
+    [string]$spaceName,
+    [string]$projectName,
+    [string]$runbookName
+)
+
+$ErrorActionPreference = "Stop";
+
+# Define working variables
+$header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
+
+# Get space
+$spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header 
+$space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
+
+# Get project
+$projects = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100" -Headers $header 
+$project = $projects.Items | Where-Object { $_.Name -eq $projectName }
+
+# Get runbook
+$runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header 
+$runbook = $runbooks.Items | Where-Object { $_.Name -eq $runbookName }
+
+# Get a runbook snapshot template
+$runbookSnapshotTemplate = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/runbookProcesses/$($runbook.RunbookProcessId)/runbookSnapshotTemplate" -Headers $header 
+
+# Create a runbook snapshot
+$body = @{
+    ProjectId = $project.Id
+    RunbookId = $runbook.Id
+    Name = $runbookSnapshotTemplate.NextNameIncrement
+    Notes = $null
+    SelectedPackages = @()
+}
+
+# Include latest built-in feed packages
+foreach($package in $runbookSnapshotTemplate.Packages)
+{
+    if($package.FeedId -eq "feeds-builtin") {
+        # Get latest package version
+        $packages = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/feeds/feeds-builtin/packages/versions?packageId=$($package.PackageId)&take=1" -Headers $header 
+        $latestPackage = $packages.Items | Select-Object -First 1
+        $package = @{
+            ActionName = $package.ActionName
+            Version = $latestPackage.Version
+            PackageReferenceName = $package.PackageReferenceName
+        }
+
+        $body.SelectedPackages += $package
+    }
+}
+
+$body = $body | ConvertTo-Json -Depth 10
+$runbookPublishedSnapshot = Invoke-RestMethod -Method Post -Uri "$octopusURL/api/$($space.Id)/runbookSnapshots?publish=true" -Body $body -Headers $header
+
+# Re-get runbook
+$runbook = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/runbooks/$($runbook.Id)" -Headers $header
+
+# Publish the snapshot
+$runbook.PublishedRunbookSnapshotId = $runbookPublishedSnapshot.Id
+Invoke-RestMethod -Method Put -Uri "$octopusURL/api/$($space.Id)/runbooks/$($runbook.Id)" -Body ($runbook | ConvertTo-Json -Depth 10) -Headers $header
+
+Write-Host "Published runbook snapshot: $($runbookPublishedSnapshot.Id) ($($runbookPublishedSnapshot.Name))"

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -11,19 +11,23 @@ $ErrorActionPreference = "Stop";
 # Define working variables
 $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 
-Write-Host "Server name $octopusURL"
-
 # Get space
 $spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header 
 $space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
+
+Write-Host "Space id $($space.Id)"
 
 # Get project
 $projects = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100" -Headers $header 
 $project = $projects.Items | Where-Object { $_.Name -eq $projectName }
 
+Write-Host "Project id $($project.Id)"
+
 # Get runbook
 $runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header 
 $runbook = $runbooks.Items | Where-Object { $_.Name -eq $runbookName }
+
+Write-Host "Runbook id $($runbook.Id)"
 
 # Get a runbook snapshot template
 $runbookSnapshotTemplate = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/runbookProcesses/$($runbook.RunbookProcessId)/runbookSnapshotTemplate" -Headers $header 

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -1,15 +1,17 @@
 param (
-    [string]$octopusURL,
-    [string]$octopusAPIKey,
-    [string]$spaceName,
-    [string]$projectName,
-    [string]$runbookName
+    [Parameter(Mandatory=$true)][string]$octopusURL,
+    [Parameter(Mandatory=$true)][string]$octopusAPIKey,
+    [Parameter(Mandatory=$true)][string]$spaceName,
+    [Parameter(Mandatory=$true)][string]$projectName,
+    [Parameter(Mandatory=$true)][string]$runbookName
 )
 
 $ErrorActionPreference = "Stop";
 
 # Define working variables
 $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
+
+Write-Host "Server name $octopusURL"
 
 # Get space
 $spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header 

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -15,18 +15,36 @@ Write-Verbose "Getting Spaces"
 # Get space
 $spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header
 $space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
+
+if([string]::IsNullOrEmpty($space))
+{
+    Write-Error "Failed to find the space with name $spaceName"
+    throw
+}
 Write-Verbose "Selected space with id $($space.Id)"
 
 Write-Verbose "Getting Projects"
 # Get project
 $projects = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100" -Headers $header
 $project = $projects.Items | Where-Object { $_.Name -eq $projectName }
+
+if([string]::IsNullOrEmpty($project))
+{
+    Write-Error "Failed to find the project with name $projectName"
+    throw
+}
 Write-Verbose "Selected project with id $($project.Id)"
 
 Write-Verbose "Getting Runbooks"
 # Get runbook
 $runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header
 $runbook = $runbooks.Items | Where-Object { $_.Name -eq $runbookName }
+
+if([string]::IsNullOrEmpty($runbook))
+{
+    Write-Error "Failed to find the runbook with name $runbookName"
+    throw
+}
 Write-Verbose "Selected runbook with id $($runbook.id)"
 
 # Get a runbook snapshot template

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -18,7 +18,9 @@ $space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
 Write-Host "Space id $($space.Id)"
 
 # Get project
-$projects = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100" -Headers $header 
+$projectsUrl = "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100"
+Write-Host $projectsUrl
+$projects = Invoke-RestMethod -Uri $projectsUrl -Headers $header
 $project = $projects.Items | Where-Object { $_.Name -eq $projectName }
 
 Write-Host "Project id $($project.Id)"

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -12,19 +12,19 @@ $ErrorActionPreference = "Stop";
 $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 
 # Get space
-$spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header 
+$spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header
 $space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
 
 # Get project
-$projects = Invoke-RestMethod -Uri $projectsUrl -Headers $header
+$projects = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100" -Headers $header
 $project = $projects.Items | Where-Object { $_.Name -eq $projectName }
 
 # Get runbook
-$runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header 
+$runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header
 $runbook = $runbooks.Items | Where-Object { $_.Name -eq $runbookName }
 
 # Get a runbook snapshot template
-$runbookSnapshotTemplate = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/runbookProcesses/$($runbook.RunbookProcessId)/runbookSnapshotTemplate" -Headers $header 
+$runbookSnapshotTemplate = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/runbookProcesses/$($runbook.RunbookProcessId)/runbookSnapshotTemplate" -Headers $header
 
 # Create a runbook snapshot
 $body = @{
@@ -40,7 +40,7 @@ foreach($package in $runbookSnapshotTemplate.Packages)
 {
     if($package.FeedId -eq "feeds-builtin") {
         # Get latest package version
-        $packages = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/feeds/feeds-builtin/packages/versions?packageId=$($package.PackageId)&take=1" -Headers $header 
+        $packages = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/feeds/feeds-builtin/packages/versions?packageId=$($package.PackageId)&take=1" -Headers $header
         $latestPackage = $packages.Items | Select-Object -First 1
         $package = @{
             ActionName = $package.ActionName

--- a/Build/UpdateRunbook.ps1
+++ b/Build/UpdateRunbook.ps1
@@ -15,21 +15,13 @@ $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 $spaces = Invoke-RestMethod -Uri "$octopusURL/api/spaces?partialName=$([uri]::EscapeDataString($spaceName))&skip=0&take=100" -Headers $header 
 $space = $spaces.Items | Where-Object { $_.Name -eq $spaceName }
 
-Write-Host "Space id $($space.Id)"
-
 # Get project
-$projectsUrl = "$octopusURL/api/$($space.Id)/projects?partialName=$([uri]::EscapeDataString($projectName))&skip=0&take=100"
-Write-Host $projectsUrl
 $projects = Invoke-RestMethod -Uri $projectsUrl -Headers $header
 $project = $projects.Items | Where-Object { $_.Name -eq $projectName }
-
-Write-Host "Project id $($project.Id)"
 
 # Get runbook
 $runbooks = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?partialName=$([uri]::EscapeDataString($runbookName))&skip=0&take=100" -Headers $header 
 $runbook = $runbooks.Items | Where-Object { $_.Name -eq $runbookName }
-
-Write-Host "Runbook id $($runbook.Id)"
 
 # Get a runbook snapshot template
 $runbookSnapshotTemplate = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/runbookProcesses/$($runbook.RunbookProcessId)/runbookSnapshotTemplate" -Headers $header 


### PR DESCRIPTION
On the Build/Test/Publish action, it runs a custom publish runbook script which gets the runbook, goes through each of the packages and selects the latest version, then creates a new snapshot. Based up: https://github.com/OctopusDeploy/docs/blob/master/docs/shared-content/scripts/create-and-publish-runbook-scripts.include.md

I've tested this in the build/test action, and you can see it was recently published which was from the script https://deploy.octopus.app/app#/Spaces-622/projects/octopus-server/operations/runbooks/Runbooks-661/snapshots/RunbookSnapshots-2581