### PR TITLE
Replace github action install octo cli with new install octo cli action

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -27,3 +27,12 @@ jobs:
           $configuration.Run.Exit = $true
           Invoke-Pester -configuration $configuration
         shell: pwsh
+
+      - name: Install Octo CLI
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
+        with:
+          version: 7.4.3140
+
+      - name: octo cli version
+        run: >
+          octo version

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -27,12 +27,3 @@ jobs:
           $configuration.Run.Exit = $true
           Invoke-Pester -configuration $configuration
         shell: pwsh
-
-      - name: Install Octo CLI
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
-        with:
-          version: 7.4.3140
-
-      - name: octo cli version
-        run: >
-          octo version

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -48,7 +48,7 @@ jobs:
         run: cp ./enthusiastic-promoter.ps1 ./packagesoutput/$OCTOPUS_PACKAGE_NAME
     
       - name: Install Octo CLI
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
+        uses: OctopusDeploy/install-octopus-cli-action
         with:
           version: latest
           

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -47,12 +47,10 @@ jobs:
         id: move-ps-script-to-build-folder
         run: cp ./enthusiastic-promoter.ps1 ./packagesoutput/$OCTOPUS_PACKAGE_NAME
     
-      - name: Install Octopus CLI
-        run: |
-          sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
-          curl -sSfL https://apt.octopus.com/public.key | sudo apt-key add - && \
-          sudo sh -c "echo deb https://apt.octopus.com/ stable main > /etc/apt/sources.list.d/octopus.com.list" && \
-          sudo apt update && sudo apt install octopuscli 
+      - name: Install Octo CLI
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
+        with:
+          version: 7.4.3140 
           
       - name: Package
         run: octo pack --id="$OCTOPUS_PACKAGE_NAME" --format="Zip" --version="$PACKAGE_VERSION" --basePath="./packagesoutput/$OCTOPUS_PACKAGE_NAME" --outFolder="./packages"

--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Octo CLI
         uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
         with:
-          version: 7.4.3140 
+          version: latest
           
       - name: Package
         run: octo pack --id="$OCTOPUS_PACKAGE_NAME" --format="Zip" --version="$PACKAGE_VERSION" --basePath="./packagesoutput/$OCTOPUS_PACKAGE_NAME" --outFolder="./packages"


### PR DESCRIPTION
Let's start using our new action as it's much nicer than what we had! 

https://github.com/marketplace/actions/install-octopus-cli#install-octopus-cli-action