### PR TITLE
Don't check Releases with no deployments check checking latest release in environment

### DIFF
--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -54,9 +54,14 @@ jobs:
           
       - name: Package
         run: octo pack --id="$OCTOPUS_PACKAGE_NAME" --format="Zip" --version="$PACKAGE_VERSION" --basePath="./packagesoutput/$OCTOPUS_PACKAGE_NAME" --outFolder="./packages"
-          
-      - name: Push to Octopus
-        run: octo push --package="./packages/$OCTOPUS_PACKAGE_NAME.$PACKAGE_VERSION.zip" --server="${{ secrets.OCTOPUS_SERVER }}" --apiKey="${{ secrets.OCTOPUS_APIKEY }}" --space="$OCTOPUS_SPACE_NAME"
+
+      - name: Push to Octopus Deploy
+        uses: OctopusDeploy/push-package-action@main
+        with:
+          api_key: ${{ secrets.OCTOPUS_APIKEY }}
+          server: ${{ secrets.OCTOPUS_SERVER }}
+          space: ${{ env.OCTOPUS_SPACE_NAME }}
+          packages: "./packages/${{env.OCTOPUS_PACKAGE_NAME}}.$PACKAGE_VERSION.zip"
 
       - name: Publish Runbook
         run: ./Build/UpdateRunbook.ps1 -octopusURL "${{ secrets.OCTOPUS_SERVER }}" -octopusAPIKey "${{ secrets.OCTOPUS_APIKEY }}" -spaceName "${{ env.OCTOPUS_SPACE_NAME }}" -projectName "${{ env.OCTOPUS_PROJECT_NAME }}" -runbookName "${{ env.OCTOPUS_ENTHUSIASTIC_PROMOTIONS_RUNBOOK_NAME }}"

--- a/SampleData/sample8-channels.json
+++ b/SampleData/sample8-channels.json
@@ -1,0 +1,334 @@
+{
+    "ItemType": "Channel",
+    "TotalResults": 6,
+    "ItemsPerPage": 30,
+    "NumberOfPages": 1,
+    "LastPageNumber": 0,
+    "Items": [
+      {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      {
+        "Id": "Channels-4448",
+        "Name": "Latest Release - 2021.1",
+        "Description": "eg: `2021.1.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1667",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "86bac821-0539-4f15-8ea3-939136619188",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "af112c81-e23f-490b-8bf9-7e9145268acd",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4448",
+          "Releases": "/api/Spaces-622/channels/Channels-4448/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      {
+        "Id": "Channels-4583",
+        "Name": "Previous Release 2 - 2020.5",
+        "Description": "eg\n`2020.5.0-rc0003`\n`2020.5.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1668",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "2cd84d29-23d9-4f8f-9035-6e54a9041fa7",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "71275451-9c17-472d-9ea5-53a3568cf603",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4583",
+          "Releases": "/api/Spaces-622/channels/Channels-4583/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      {
+        "Id": "Channels-4449",
+        "Name": "Previous Release 3 - 2020.4",
+        "Description": "eg\n`2020.4.0-rc0003`\n`2020.4.0`\n",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1668",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "d6f4809f-918a-4c9e-8de8-ff1bdb63e2e9",
+            "VersionRange": "[2020.4.0-a,2020.4.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e8dbbe59-4ac5-4c0f-b145-c31f65f6fc36",
+            "VersionRange": "[2020.4.0-a,2020.4.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {
+              
+            },
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [
+          
+        ],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4449",
+          "Releases": "/api/Spaces-622/channels/Channels-4449/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      }
+    ],
+    "Links": {
+      "Self": "/api/Spaces-622/projects/Projects-4224/channels?skip=0&take=30",
+      "Template": "/api/Spaces-622/projects/Projects-4224/channels{?skip,take,partialName}",
+      "Page.All": "/api/Spaces-622/projects/Projects-4224/channels?skip=0&take=2147483647",
+      "Page.Current": "/api/Spaces-622/projects/Projects-4224/channels?skip=0&take=30",
+      "Page.Last": "/api/Spaces-622/projects/Projects-4224/channels?skip=0&take=30"
+    }
+  }

--- a/SampleData/sample8.json
+++ b/SampleData/sample8.json
@@ -1,0 +1,5593 @@
+{
+  "Environments": [
+    {
+      "Id": "Environments-2583",
+      "Name": "Branch Instances (Staging)"
+    },
+    {
+      "Id": "Environments-2621",
+      "Name": "Octopus Cloud Tests"
+    },
+    {
+      "Id": "Environments-2601",
+      "Name": "Production"
+    },
+    {
+      "Id": "Environments-2584",
+      "Name": "Branch Instances (Prod)"
+    },
+    {
+      "Id": "Environments-2585",
+      "Name": "Staff"
+    },
+    {
+      "Id": "Environments-2586",
+      "Name": "Friends of Octopus"
+    },
+    {
+      "Id": "Environments-2587",
+      "Name": "Early Adopters"
+    },
+    {
+      "Id": "Environments-2588",
+      "Name": "Stable"
+    },
+    {
+      "Id": "Environments-2589",
+      "Name": "General Availablilty"
+    }
+  ],
+  "ChannelEnvironments": {
+    "Channels-4447": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      }
+    ],
+    "Channels-4448": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      },
+      {
+        "Id": "Environments-2621",
+        "Name": "Octopus Cloud Tests"
+      },
+      {
+        "Id": "Environments-2601",
+        "Name": "Production"
+      },
+      {
+        "Id": "Environments-2584",
+        "Name": "Branch Instances (Prod)"
+      },
+      {
+        "Id": "Environments-2586",
+        "Name": "Friends of Octopus"
+      },
+      {
+        "Id": "Environments-2587",
+        "Name": "Early Adopters"
+      },
+      {
+        "Id": "Environments-2588",
+        "Name": "Stable"
+      }
+    ],
+    "Channels-4449": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      },
+      {
+        "Id": "Environments-2601",
+        "Name": "Production"
+      },
+      {
+        "Id": "Environments-2589",
+        "Name": "General Availablilty"
+      }
+    ],
+    "Channels-4583": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      },
+      {
+        "Id": "Environments-2601",
+        "Name": "Production"
+      },
+      {
+        "Id": "Environments-2589",
+        "Name": "General Availablilty"
+      }
+    ],
+    "Channels-4847": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      },
+      {
+        "Id": "Environments-2621",
+        "Name": "Octopus Cloud Tests"
+      },
+      {
+        "Id": "Environments-2601",
+        "Name": "Production"
+      },
+      {
+        "Id": "Environments-2586",
+        "Name": "Friends of Octopus"
+      },
+      {
+        "Id": "Environments-2587",
+        "Name": "Early Adopters"
+      },
+      {
+        "Id": "Environments-2588",
+        "Name": "Stable"
+      },
+      {
+        "Id": "Environments-2589",
+        "Name": "General Availablilty"
+      }
+    ],
+    "Channels-4946": [
+      {
+        "Id": "Environments-2583",
+        "Name": "Branch Instances (Staging)"
+      },
+      {
+        "Id": "Environments-2621",
+        "Name": "Octopus Cloud Tests"
+      },
+      {
+        "Id": "Environments-2601",
+        "Name": "Production"
+      },
+      {
+        "Id": "Environments-2584",
+        "Name": "Branch Instances (Prod)"
+      },
+      {
+        "Id": "Environments-2585",
+        "Name": "Staff"
+      }
+    ]
+  },
+  "Releases": [
+    {
+      "Release": {
+        "Id": "Releases-87289",
+        "Version": "2021.2.1924-bug-fix-step-package-store",
+        "ChannelId": "Channels-4447",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1924-bug-fix-step-package-store",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1924-bug-fix-step-package-store",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240679",
+            "Branch": "pull/8667",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "39e062a80c8bd1be8bc70f5874547614484e67d2",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/39e062a80c8bd1be8bc70f5874547614484e67d2",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "39e062a80c8bd1be8bc70f5874547614484e67d2",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/39e062a80c8bd1be8bc70f5874547614484e67d2",
+                "Comment": "Be kind and rewind\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1924-bug-fix-step-package-store",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1924-bug-fix-step-package-store",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240679",
+            "Branch": "pull/8667",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "39e062a80c8bd1be8bc70f5874547614484e67d2",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/39e062a80c8bd1be8bc70f5874547614484e67d2",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "39e062a80c8bd1be8bc70f5874547614484e67d2",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/39e062a80c8bd1be8bc70f5874547614484e67d2",
+                "Comment": "Be kind and rewind\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T23:41:33.796+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1924-bug-fix-step-package-store",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1924-bug-fix-step-package-store",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87289",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87289/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87289/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87289/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87289",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87289",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87289/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87289/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87289/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87289/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87289/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87282",
+        "Version": "2021.1.6981",
+        "ChannelId": "Channels-4448",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.1.6981",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6981",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240451",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.1.6981",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6981",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240451",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-14T22:13:58.519+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.1.6981",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.1.6981",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87282",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87282/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87282/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87282/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87282",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87282",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87282/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87282/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87282/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87282/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87282/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4448",
+        "Name": "Latest Release - 2021.1",
+        "Description": "eg: `2021.1.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1667",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "86bac821-0539-4f15-8ea3-939136619188",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "af112c81-e23f-490b-8bf9-7e9145268acd",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4448",
+          "Releases": "/api/Spaces-622/channels/Channels-4448/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87281",
+        "Version": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+        "ChannelId": "Channels-4447",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240523",
+            "Branch": "refs/heads/mergebot/from-release/2021.1-to-master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+                "Comment": "Changes the behaviour of StepPackageInputProcessor (#8666)\n\nUses a Calamari-contributed variable instead of one set by package aquisition."
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240523",
+            "Branch": "refs/heads/mergebot/from-release/2021.1-to-master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1fa040a6623f0b0d65f7c262e5574e1c1c955860",
+                "Comment": "Changes the behaviour of StepPackageInputProcessor (#8666)\n\nUses a Calamari-contributed variable instead of one set by package aquisition."
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T22:13:48.432+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1943-mergebot-from-release-2021.1-to-master",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87281",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87281/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87281/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87281/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87281",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87281",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87281/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87281/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87281/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87281/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87281/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87278",
+        "Version": "2020.5.340",
+        "ChannelId": "Channels-4583",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.5.340",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.340",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240207",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.5.340",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.340",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2240207",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-14T21:12:21.485+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.5.340",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.5.340",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87278",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87278/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87278/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87278/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87278",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87278",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87278/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87278/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87278/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87278/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87278/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4583",
+        "Name": "Previous Release 2 - 2020.5",
+        "Description": "eg\n`2020.5.0-rc0003`\n`2020.5.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1668",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "2cd84d29-23d9-4f8f-9035-6e54a9041fa7",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "71275451-9c17-472d-9ea5-53a3568cf603",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4583",
+          "Releases": "/api/Spaces-622/channels/Channels-4583/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87240",
+        "Version": "2021.2.1939-enh-k8s-pod-service-account",
+        "ChannelId": "Channels-4447",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1939-enh-k8s-pod-service-account",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1939-enh-k8s-pod-service-account",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2239957",
+            "Branch": "pull/8637",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "499f7946235f7d659c36ec119c5e927390a0168e",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/499f7946235f7d659c36ec119c5e927390a0168e",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "499f7946235f7d659c36ec119c5e927390a0168e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/499f7946235f7d659c36ec119c5e927390a0168e",
+                "Comment": "Updated: Calamari version\n\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1939-enh-k8s-pod-service-account",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1939-enh-k8s-pod-service-account",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2239957",
+            "Branch": "pull/8637",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "499f7946235f7d659c36ec119c5e927390a0168e",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/499f7946235f7d659c36ec119c5e927390a0168e",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "499f7946235f7d659c36ec119c5e927390a0168e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/499f7946235f7d659c36ec119c5e927390a0168e",
+                "Comment": "Updated: Calamari version\n\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T11:33:07.350+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1939-enh-k8s-pod-service-account",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1939-enh-k8s-pod-service-account",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87240",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87240/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87240/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87240/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87240",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87240",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87240/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87240/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87240/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87240/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87240/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87201",
+        "Version": "2021.2.1919",
+        "ChannelId": "Channels-4946",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1919",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1919",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238441",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+                "Comment": "Merge pull request #8663 from OctopusDeploy/rhysparry/kubernetes-step-typos\n\nFix typos in Deploy Kubernetes Container Step"
+              },
+              {
+                "Id": "25ca8160d6add671a63933001c1667a0b3b5c3f5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/25ca8160d6add671a63933001c1667a0b3b5c3f5",
+                "Comment": "Merge pull request #8662 from OctopusDeploy/rhysparry/spaces-in-project-path\n\nPermit spaces in the Project path during pre-build"
+              },
+              {
+                "Id": "79c01dc6f51843d0b4303366c2a13678ed92a883",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/79c01dc6f51843d0b4303366c2a13678ed92a883",
+                "Comment": "Fix Typo 'readniess' -> 'readiness'\n"
+              },
+              {
+                "Id": "c8a98bea265e265ecc39c13f38eb59e6fba43d09",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c8a98bea265e265ecc39c13f38eb59e6fba43d09",
+                "Comment": "Add missing space\n"
+              },
+              {
+                "Id": "6c112e00e3267519a2f54d75a6f8ebac2ec856e5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/6c112e00e3267519a2f54d75a6f8ebac2ec856e5",
+                "Comment": "Escape single quotes in ProjectDir\n"
+              },
+              {
+                "Id": "a0e1ecee9b6c07858ac906634f9baf03d78cbb65",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a0e1ecee9b6c07858ac906634f9baf03d78cbb65",
+                "Comment": "Add quotes around StopOctopusServices.ps1 script call\n\nEnables running the PreBuild step when a space or other special\ncharacter may appear in the path.\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1919",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1919",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238441",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e0e1b9b3663d540d8a34e7d946cdb4efff09446",
+                "Comment": "Merge pull request #8663 from OctopusDeploy/rhysparry/kubernetes-step-typos\n\nFix typos in Deploy Kubernetes Container Step"
+              },
+              {
+                "Id": "25ca8160d6add671a63933001c1667a0b3b5c3f5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/25ca8160d6add671a63933001c1667a0b3b5c3f5",
+                "Comment": "Merge pull request #8662 from OctopusDeploy/rhysparry/spaces-in-project-path\n\nPermit spaces in the Project path during pre-build"
+              },
+              {
+                "Id": "79c01dc6f51843d0b4303366c2a13678ed92a883",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/79c01dc6f51843d0b4303366c2a13678ed92a883",
+                "Comment": "Fix Typo 'readniess' -> 'readiness'\n"
+              },
+              {
+                "Id": "c8a98bea265e265ecc39c13f38eb59e6fba43d09",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c8a98bea265e265ecc39c13f38eb59e6fba43d09",
+                "Comment": "Add missing space\n"
+              },
+              {
+                "Id": "6c112e00e3267519a2f54d75a6f8ebac2ec856e5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/6c112e00e3267519a2f54d75a6f8ebac2ec856e5",
+                "Comment": "Escape single quotes in ProjectDir\n"
+              },
+              {
+                "Id": "a0e1ecee9b6c07858ac906634f9baf03d78cbb65",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a0e1ecee9b6c07858ac906634f9baf03d78cbb65",
+                "Comment": "Add quotes around StopOctopusServices.ps1 script call\n\nEnables running the PreBuild step when a space or other special\ncharacter may appear in the path.\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T05:34:38.672+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1919",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1919",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87201",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87201/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87201/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87201/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87201",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87201",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87201/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87201/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87201/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87201/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87201/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87199",
+        "Version": "2021.2.1917",
+        "ChannelId": "Channels-4946",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1917",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1917",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238165",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+                "Comment": "Add stub schema controller for step inputs (#8661)\n\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1917",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1917",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238165",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e17c7f220dd012830c8e17e93db17e0e50b0ac4e",
+                "Comment": "Add stub schema controller for step inputs (#8661)\n\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T05:01:33.643+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1917",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1917",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87199",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87199/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87199/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87199/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87199",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87199",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87199/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87199/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87199/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87199/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87199/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87190",
+        "Version": "2021.2.1901",
+        "ChannelId": "Channels-4946",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1901",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1901",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238002",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "a74cd1b88d4593cba72291afc49e295aa774b3f7",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a74cd1b88d4593cba72291afc49e295aa774b3f7",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1901",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1901",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2238002",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "a74cd1b88d4593cba72291afc49e295aa774b3f7",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a74cd1b88d4593cba72291afc49e295aa774b3f7",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-14T03:57:29.887+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1901",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1901",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87190",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87190/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87190/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87190/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87190",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87190",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87190/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87190/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87190/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87190/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87190/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {},
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87163",
+        "Version": "2021.2.1899-enh-k8s-pod-service-account",
+        "ChannelId": "Channels-4447",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1899-enh-k8s-pod-service-account",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1899-enh-k8s-pod-service-account",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2236635",
+            "Branch": "pull/8637",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "28ec5c718612391dc4dc233213dc07881ffa06dc",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/28ec5c718612391dc4dc233213dc07881ffa06dc",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "28ec5c718612391dc4dc233213dc07881ffa06dc",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/28ec5c718612391dc4dc233213dc07881ffa06dc",
+                "Comment": "Reverted: ClientVersusServerResources test output\n\n"
+              },
+              {
+                "Id": "df1d56ebb379cf2a5e3ca7c8df5a93b1418c3e73",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/df1d56ebb379cf2a5e3ca7c8df5a93b1418c3e73",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account"
+              },
+              {
+                "Id": "40b805032219fdf9dd079957780a239b98be20b5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/40b805032219fdf9dd079957780a239b98be20b5",
+                "Comment": "Trigger chain build\n"
+              },
+              {
+                "Id": "859c68a7de6b483e16242dfbef4ab9160f72d663",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/859c68a7de6b483e16242dfbef4ab9160f72d663",
+                "Comment": "Fixed: Hide skip TLS option when there is a ca path provided\n\n"
+              },
+              {
+                "Id": "a0975277daedd42ff27a3334f5ed18d4fae025f1",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a0975277daedd42ff27a3334f5ed18d4fae025f1",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "ce124c6a79308797bcf4c861a3c79acc5ea0f4c0",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/ce124c6a79308797bcf4c861a3c79acc5ea0f4c0",
+                "Comment": "Temp fixed: CompareClientAndServerResources test\n\n"
+              },
+              {
+                "Id": "e8aabe6dc4a8e4784a2336a40bcbd77a04aa486a",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e8aabe6dc4a8e4784a2336a40bcbd77a04aa486a",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "41acab73e8e3fe153f611344e63d37d449468042",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/41acab73e8e3fe153f611344e63d37d449468042",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "ac3ccf53b544eb67a75970b0d47fc2d4c63346ac",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/ac3ccf53b544eb67a75970b0d47fc2d4c63346ac",
+                "Comment": "Updated: OctopusClient version\n\n"
+              },
+              {
+                "Id": "5fda41f37bcfb40d08e327d4ca31619ecb6ec9ae",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/5fda41f37bcfb40d08e327d4ca31619ecb6ec9ae",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "be7a87409d45153619dd122e840a8492b8ed9869",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/be7a87409d45153619dd122e840a8492b8ed9869",
+                "Comment": "Fixed: ClusterCertificatePath data type\n\n"
+              },
+              {
+                "Id": "23ec66901eaf7a38491b8c98098a0c46115ae25b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/23ec66901eaf7a38491b8c98098a0c46115ae25b",
+                "Comment": "Added: placeholders for Token path and CA path\n\n"
+              },
+              {
+                "Id": "b0c2a8494fd9989ca80819c5cbc0639074dc3e9f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b0c2a8494fd9989ca80819c5cbc0639074dc3e9f",
+                "Comment": "Fixed: cluster CA path isn't saved correctly\n\n"
+              },
+              {
+                "Id": "198656881d0643f14428a965d068adda70ff3d0b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/198656881d0643f14428a965d068adda70ff3d0b",
+                "Comment": "Changed: display a certificate path input when Pod Service Account is selected\n\n"
+              },
+              {
+                "Id": "1e6c7ca6c34d87f9c245d7027332df4f0e0d0e67",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e6c7ca6c34d87f9c245d7027332df4f0e0d0e67",
+                "Comment": "Added: ability to configure Pod Service Account for k8s deployment targets\n\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1899-enh-k8s-pod-service-account",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1899-enh-k8s-pod-service-account",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2236635",
+            "Branch": "pull/8637",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "28ec5c718612391dc4dc233213dc07881ffa06dc",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/28ec5c718612391dc4dc233213dc07881ffa06dc",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "28ec5c718612391dc4dc233213dc07881ffa06dc",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/28ec5c718612391dc4dc233213dc07881ffa06dc",
+                "Comment": "Reverted: ClientVersusServerResources test output\n\n"
+              },
+              {
+                "Id": "df1d56ebb379cf2a5e3ca7c8df5a93b1418c3e73",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/df1d56ebb379cf2a5e3ca7c8df5a93b1418c3e73",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account"
+              },
+              {
+                "Id": "40b805032219fdf9dd079957780a239b98be20b5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/40b805032219fdf9dd079957780a239b98be20b5",
+                "Comment": "Trigger chain build\n"
+              },
+              {
+                "Id": "859c68a7de6b483e16242dfbef4ab9160f72d663",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/859c68a7de6b483e16242dfbef4ab9160f72d663",
+                "Comment": "Fixed: Hide skip TLS option when there is a ca path provided\n\n"
+              },
+              {
+                "Id": "a0975277daedd42ff27a3334f5ed18d4fae025f1",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a0975277daedd42ff27a3334f5ed18d4fae025f1",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "ce124c6a79308797bcf4c861a3c79acc5ea0f4c0",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/ce124c6a79308797bcf4c861a3c79acc5ea0f4c0",
+                "Comment": "Temp fixed: CompareClientAndServerResources test\n\n"
+              },
+              {
+                "Id": "e8aabe6dc4a8e4784a2336a40bcbd77a04aa486a",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e8aabe6dc4a8e4784a2336a40bcbd77a04aa486a",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "41acab73e8e3fe153f611344e63d37d449468042",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/41acab73e8e3fe153f611344e63d37d449468042",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "ac3ccf53b544eb67a75970b0d47fc2d4c63346ac",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/ac3ccf53b544eb67a75970b0d47fc2d4c63346ac",
+                "Comment": "Updated: OctopusClient version\n\n"
+              },
+              {
+                "Id": "5fda41f37bcfb40d08e327d4ca31619ecb6ec9ae",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/5fda41f37bcfb40d08e327d4ca31619ecb6ec9ae",
+                "Comment": "Merge branch 'master' into enh-k8s-pod-service-account\n\n"
+              },
+              {
+                "Id": "be7a87409d45153619dd122e840a8492b8ed9869",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/be7a87409d45153619dd122e840a8492b8ed9869",
+                "Comment": "Fixed: ClusterCertificatePath data type\n\n"
+              },
+              {
+                "Id": "23ec66901eaf7a38491b8c98098a0c46115ae25b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/23ec66901eaf7a38491b8c98098a0c46115ae25b",
+                "Comment": "Added: placeholders for Token path and CA path\n\n"
+              },
+              {
+                "Id": "b0c2a8494fd9989ca80819c5cbc0639074dc3e9f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b0c2a8494fd9989ca80819c5cbc0639074dc3e9f",
+                "Comment": "Fixed: cluster CA path isn't saved correctly\n\n"
+              },
+              {
+                "Id": "198656881d0643f14428a965d068adda70ff3d0b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/198656881d0643f14428a965d068adda70ff3d0b",
+                "Comment": "Changed: display a certificate path input when Pod Service Account is selected\n\n"
+              },
+              {
+                "Id": "1e6c7ca6c34d87f9c245d7027332df4f0e0d0e67",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1e6c7ca6c34d87f9c245d7027332df4f0e0d0e67",
+                "Comment": "Added: ability to configure Pod Service Account for k8s deployment targets\n\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T01:03:33.557+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1899-enh-k8s-pod-service-account",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1899-enh-k8s-pod-service-account",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87163",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87163/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87163/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87163/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87163",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87163",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87163/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87163/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87163/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87163/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87163/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107889",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87163",
+            "DeploymentId": "Deployments-107889",
+            "TaskId": "ServerTasks-1485662",
+            "TenantId": null,
+            "ChannelId": "Channels-4447",
+            "ReleaseVersion": "2021.2.1899-enh-k8s-pod-service-account",
+            "Created": "2021-04-14T01:03:34.053+00:00",
+            "QueueTime": "2021-04-14T01:03:34.054+00:00",
+            "StartTime": "2021-04-14T01:03:34.621+00:00",
+            "CompletedTime": null,
+            "State": "Canceled",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "\r\nThe task was executing, but was canceled as task cancellation was requested when the Octopus Server node that was executing the task was put into drain mode.\r\nThe task was in the process of being canceled, but the Octopus Server process that was executing the task was terminated before the task could be fully canceled. This task may be in an inconsistent state.",
+            "Duration": "23 hours",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107889",
+              "Release": "/api/Spaces-622/releases/Releases-87163",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1485662"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2583"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87156",
+        "Version": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+        "ChannelId": "Channels-4447",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2236707",
+            "Branch": "refs/heads/mergebot/from-release/2021.1-to-master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "89f29f10f4525cc8a554510eafaf606b99170433",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/89f29f10f4525cc8a554510eafaf606b99170433",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "89f29f10f4525cc8a554510eafaf606b99170433",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/89f29f10f4525cc8a554510eafaf606b99170433",
+                "Comment": "Fixing merge-forward conflict\n"
+              },
+              {
+                "Id": "672fcb4474b5393d741d79f2ffb5eae16b9d012a",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/672fcb4474b5393d741d79f2ffb5eae16b9d012a",
+                "Comment": "Merge branch 'release/2021.1' into mergebot/from-release/2021.1-to-master\n"
+              },
+              {
+                "Id": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "Comment": "Merge pull request #8651 from OctopusDeploy/andrew-w/2021-1-issue-6811\n\nAndrew w/2021 1 issue 6811"
+              },
+              {
+                "Id": "1c053246ac608d93debe45347b1929267b84c528",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1c053246ac608d93debe45347b1929267b84c528",
+                "Comment": "Class rename\n"
+              },
+              {
+                "Id": "d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "Comment": "Update MultiSelect.tsx\n"
+              },
+              {
+                "Id": "3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "Comment": "Fixing display of MultiSelect in scrolling dialog\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2236707",
+            "Branch": "refs/heads/mergebot/from-release/2021.1-to-master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "89f29f10f4525cc8a554510eafaf606b99170433",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/89f29f10f4525cc8a554510eafaf606b99170433",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "89f29f10f4525cc8a554510eafaf606b99170433",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/89f29f10f4525cc8a554510eafaf606b99170433",
+                "Comment": "Fixing merge-forward conflict\n"
+              },
+              {
+                "Id": "672fcb4474b5393d741d79f2ffb5eae16b9d012a",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/672fcb4474b5393d741d79f2ffb5eae16b9d012a",
+                "Comment": "Merge branch 'release/2021.1' into mergebot/from-release/2021.1-to-master\n"
+              },
+              {
+                "Id": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "Comment": "Merge pull request #8651 from OctopusDeploy/andrew-w/2021-1-issue-6811\n\nAndrew w/2021 1 issue 6811"
+              },
+              {
+                "Id": "1c053246ac608d93debe45347b1929267b84c528",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1c053246ac608d93debe45347b1929267b84c528",
+                "Comment": "Class rename\n"
+              },
+              {
+                "Id": "d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "Comment": "Update MultiSelect.tsx\n"
+              },
+              {
+                "Id": "3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "Comment": "Fixing display of MultiSelect in scrolling dialog\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-14T00:25:39.066+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87156",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87156/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87156/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87156/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87156",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87156",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87156/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87156/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87156/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87156/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87156/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4447",
+        "Name": "Branch Builds",
+        "Description": "eg:\n`2020.5.0-bug-cloudservice0001`\n`2020.5.0-mergebot-from-re031`\n`2020.5.0-pr6834-0286`\n`2020.5.0-beta0652`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1665",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "bfe53c6a-6e6c-46c2-8a2f-d7dee7dd1709",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "bbb6f565-7ff3-4911-bda3-b9cfa2632e3c",
+            "VersionRange": "",
+            "Tag": "^.+$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4447",
+          "Releases": "/api/Spaces-622/channels/Channels-4447/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107881",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87156",
+            "DeploymentId": "Deployments-107881",
+            "TaskId": "ServerTasks-1485555",
+            "TenantId": null,
+            "ChannelId": "Channels-4447",
+            "ReleaseVersion": "2021.2.1895-mergebot-from-release-2021.1-to-master",
+            "Created": "2021-04-14T00:25:39.466+00:00",
+            "QueueTime": "2021-04-14T00:25:39.467+00:00",
+            "StartTime": "2021-04-14T00:25:40.142+00:00",
+            "CompletedTime": "2021-04-14T00:40:28.224+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "15 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107881",
+              "Release": "/api/Spaces-622/releases/Releases-87156",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1485555"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87106",
+        "Version": "2021.1.6977",
+        "ChannelId": "Channels-4448",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.1.6977",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6977",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2235116",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "Comment": "Merge pull request #8651 from OctopusDeploy/andrew-w/2021-1-issue-6811\n\nAndrew w/2021 1 issue 6811"
+              },
+              {
+                "Id": "1c053246ac608d93debe45347b1929267b84c528",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1c053246ac608d93debe45347b1929267b84c528",
+                "Comment": "Class rename\n"
+              },
+              {
+                "Id": "d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "Comment": "Update MultiSelect.tsx\n"
+              },
+              {
+                "Id": "3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "Comment": "Fixing display of MultiSelect in scrolling dialog\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.1.6977",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6977",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2235116",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/00df6ce55e9a618a91cdbd0b513eeb0360476991",
+                "Comment": "Merge pull request #8651 from OctopusDeploy/andrew-w/2021-1-issue-6811\n\nAndrew w/2021 1 issue 6811"
+              },
+              {
+                "Id": "1c053246ac608d93debe45347b1929267b84c528",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/1c053246ac608d93debe45347b1929267b84c528",
+                "Comment": "Class rename\n"
+              },
+              {
+                "Id": "d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/d3f25b8a7b07181ef71617ef40335f1ce3a57745",
+                "Comment": "Update MultiSelect.tsx\n"
+              },
+              {
+                "Id": "3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3c26a941245014a24c11b4cd7d08800402b5ca75",
+                "Comment": "Fixing display of MultiSelect in scrolling dialog\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-13T15:02:03.030+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.1.6977",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.1.6977",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87106",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87106/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87106/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87106/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87106",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87106",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87106/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87106/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87106/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87106/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87106/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4448",
+        "Name": "Latest Release - 2021.1",
+        "Description": "eg: `2021.1.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1667",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "86bac821-0539-4f15-8ea3-939136619188",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "af112c81-e23f-490b-8bf9-7e9145268acd",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4448",
+          "Releases": "/api/Spaces-622/channels/Channels-4448/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107808",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87106",
+            "DeploymentId": "Deployments-107808",
+            "TaskId": "ServerTasks-1483967",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6977",
+            "Created": "2021-04-13T15:02:03.356+00:00",
+            "QueueTime": "2021-04-13T15:02:03.356+00:00",
+            "StartTime": "2021-04-13T15:02:03.810+00:00",
+            "CompletedTime": "2021-04-13T15:25:20.018+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "23 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107808",
+              "Release": "/api/Spaces-622/releases/Releases-87106",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483967"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107809",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87106",
+            "DeploymentId": "Deployments-107809",
+            "TaskId": "ServerTasks-1484034",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6977",
+            "Created": "2021-04-13T15:27:22.307+00:00",
+            "QueueTime": "2021-04-13T15:27:22.267+00:00",
+            "StartTime": "2021-04-13T15:27:22.698+00:00",
+            "CompletedTime": "2021-04-13T16:09:31.985+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "42 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107809",
+              "Release": "/api/Spaces-622/releases/Releases-87106",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1484034"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107810",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87106",
+            "DeploymentId": "Deployments-107810",
+            "TaskId": "ServerTasks-1484156",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6977",
+            "Created": "2021-04-13T16:11:16.979+00:00",
+            "QueueTime": "2021-04-13T16:11:16.945+00:00",
+            "StartTime": "2021-04-13T16:11:17.640+00:00",
+            "CompletedTime": "2021-04-13T16:14:35.134+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "3 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107810",
+              "Release": "/api/Spaces-622/releases/Releases-87106",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1484156"
+            }
+          }
+        ],
+        "Environments-2584": [
+          {
+            "Id": "Deployments-107992",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2584",
+            "ReleaseId": "Releases-87106",
+            "DeploymentId": "Deployments-107992",
+            "TaskId": "ServerTasks-1487865",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6977",
+            "Created": "2021-04-14T16:16:04.372+00:00",
+            "QueueTime": "2021-04-14T16:16:04.341+00:00",
+            "StartTime": "2021-04-14T16:16:04.740+00:00",
+            "CompletedTime": "2021-04-14T16:26:06.477+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "10 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107992",
+              "Release": "/api/Spaces-622/releases/Releases-87106",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1487865"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2586"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87093",
+        "Version": "2020.6.4859",
+        "ChannelId": "Channels-4847",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.6.4859",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4859",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2234393",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.6.4859",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4859",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2234393",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-13T09:55:03.321+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.6.4859",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.6.4859",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87093",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87093/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87093/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87093/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87093",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87093",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87093/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87093/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87093/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87093/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87093/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107774",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87093",
+            "DeploymentId": "Deployments-107774",
+            "TaskId": "ServerTasks-1483107",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4859",
+            "Created": "2021-04-13T09:55:03.733+00:00",
+            "QueueTime": "2021-04-13T09:55:03.733+00:00",
+            "StartTime": "2021-04-13T10:01:58.675+00:00",
+            "CompletedTime": "2021-04-13T10:14:12.193+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "19 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107774",
+              "Release": "/api/Spaces-622/releases/Releases-87093",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483107"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107786",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87093",
+            "DeploymentId": "Deployments-107786",
+            "TaskId": "ServerTasks-1483243",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4859",
+            "Created": "2021-04-13T10:41:08.688+00:00",
+            "QueueTime": "2021-04-13T10:41:08.660+00:00",
+            "StartTime": "2021-04-13T10:41:09.271+00:00",
+            "CompletedTime": "2021-04-13T11:45:16.359+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "1 hour",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107786",
+              "Release": "/api/Spaces-622/releases/Releases-87093",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483243"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107800",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87093",
+            "DeploymentId": "Deployments-107800",
+            "TaskId": "ServerTasks-1483425",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4859",
+            "Created": "2021-04-13T11:47:06.102+00:00",
+            "QueueTime": "2021-04-13T11:47:06.070+00:00",
+            "StartTime": "2021-04-13T11:47:06.552+00:00",
+            "CompletedTime": "2021-04-13T12:13:16.100+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "26 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107800",
+              "Release": "/api/Spaces-622/releases/Releases-87093",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483425"
+            }
+          }
+        ],
+        "Environments-2586": [
+          {
+            "Id": "Deployments-107855",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2586",
+            "ReleaseId": "Releases-87093",
+            "DeploymentId": "Deployments-107855",
+            "TaskId": "ServerTasks-1484970",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4859",
+            "Created": "2021-04-13T20:53:11.873+00:00",
+            "QueueTime": "2021-04-13T20:53:11.841+00:00",
+            "StartTime": "2021-04-13T20:53:12.274+00:00",
+            "CompletedTime": "2021-04-13T21:12:26.375+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "19 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107855",
+              "Release": "/api/Spaces-622/releases/Releases-87093",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1484970"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2587"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87092",
+        "Version": "2020.6.4858",
+        "ChannelId": "Channels-4847",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-204-JS4W6",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.6.4858",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4858",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2234345",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.6.4858",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4858",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2234345",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-13T09:49:33.998+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.6.4858",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.6.4858",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87092",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87092/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87092/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87092/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87092",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-204-JS4W6",
+          "Web": "/app#/Spaces-622/releases/Releases-87092",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87092/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87092/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87092/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87092/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87092/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107773",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87092",
+            "DeploymentId": "Deployments-107773",
+            "TaskId": "ServerTasks-1483094",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4858",
+            "Created": "2021-04-13T09:49:34.374+00:00",
+            "QueueTime": "2021-04-13T09:49:34.374+00:00",
+            "StartTime": "2021-04-13T09:49:34.873+00:00",
+            "CompletedTime": "2021-04-13T10:01:32.349+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "12 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107773",
+              "Release": "/api/Spaces-622/releases/Releases-87092",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483094"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107780",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87092",
+            "DeploymentId": "Deployments-107780",
+            "TaskId": "ServerTasks-1483136",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4858",
+            "Created": "2021-04-13T10:02:49.785+00:00",
+            "QueueTime": "2021-04-13T10:02:49.748+00:00",
+            "StartTime": "2021-04-13T10:02:50.245+00:00",
+            "CompletedTime": "2021-04-13T10:38:58.469+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "36 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107780",
+              "Release": "/api/Spaces-622/releases/Releases-87092",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483136"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107785",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87092",
+            "DeploymentId": "Deployments-107785",
+            "TaskId": "ServerTasks-1483242",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4858",
+            "Created": "2021-04-13T10:41:05.119+00:00",
+            "QueueTime": "2021-04-13T10:41:05.086+00:00",
+            "StartTime": "2021-04-13T10:41:05.528+00:00",
+            "CompletedTime": "2021-04-13T11:16:57.625+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "36 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107785",
+              "Release": "/api/Spaces-622/releases/Releases-87092",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483242"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2586"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87057",
+        "Version": "2020.6.4855",
+        "ChannelId": "Channels-4847",
+        "ReleaseNotes": "\n  - [6825](https://github.com/OctopusDeploy/Issues/issues/6825) - Package upload no longer fails if there are more than 2100 projects with ARC enabled\n",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.6.4855",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4855",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2232088",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": "GitHub",
+            "WorkItems": [
+              {
+                "Id": "6825",
+                "LinkUrl": "https://github.com/OctopusDeploy/Issues/issues/6825",
+                "Source": "GitHub",
+                "Description": "Package upload no longer fails if there are more than 2100 projects with ARC enabled"
+              }
+            ],
+            "Commits": [
+              {
+                "Id": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+                "Comment": "Merge branch 'refs/heads/mergebot/from-release/2020.5-to-release/2020.6'"
+              },
+              {
+                "Id": "e532fb0febb0b12310b449c5cd66448727d3367f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e532fb0febb0b12310b449c5cd66448727d3367f",
+                "Comment": "Merge pull request #8652 from OctopusDeploy/robw/packageUpload2100\n\nBatched the retrieval of the project settings to avoid the 2100 parameter limit"
+              },
+              {
+                "Id": "467748b01d6d1ca67a5b25528bfca7f861b26b18",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/467748b01d6d1ca67a5b25528bfca7f861b26b18",
+                "Comment": "Merge branch 'release/2020.5' into mergebot/from-release/2020.5-to-release/2020.6\n"
+              },
+              {
+                "Id": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "Comment": "Removed duplicate project entry\n"
+              },
+              {
+                "Id": "544a3a72680fc96fad194d74fe77a5d31f131eec",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/544a3a72680fc96fad194d74fe77a5d31f131eec",
+                "Comment": "Batched the retrieval of the project settings to avoid the 2100 parameter limit\n\nFixes https://github.com/OctopusDeploy/Issues/issues/6825\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.6.4855",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4855",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2232088",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+            "IssueTrackerName": "GitHub",
+            "WorkItems": [
+              {
+                "Id": "6825",
+                "LinkUrl": "https://github.com/OctopusDeploy/Issues/issues/6825",
+                "Source": "GitHub",
+                "Description": "Package upload no longer fails if there are more than 2100 projects with ARC enabled"
+              }
+            ],
+            "Commits": [
+              {
+                "Id": "b6040013f55398b1b63c8c304b1940cb92dc9647",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b6040013f55398b1b63c8c304b1940cb92dc9647",
+                "Comment": "Merge branch 'refs/heads/mergebot/from-release/2020.5-to-release/2020.6'"
+              },
+              {
+                "Id": "e532fb0febb0b12310b449c5cd66448727d3367f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e532fb0febb0b12310b449c5cd66448727d3367f",
+                "Comment": "Merge pull request #8652 from OctopusDeploy/robw/packageUpload2100\n\nBatched the retrieval of the project settings to avoid the 2100 parameter limit"
+              },
+              {
+                "Id": "467748b01d6d1ca67a5b25528bfca7f861b26b18",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/467748b01d6d1ca67a5b25528bfca7f861b26b18",
+                "Comment": "Merge branch 'release/2020.5' into mergebot/from-release/2020.5-to-release/2020.6\n"
+              },
+              {
+                "Id": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "Comment": "Removed duplicate project entry\n"
+              },
+              {
+                "Id": "544a3a72680fc96fad194d74fe77a5d31f131eec",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/544a3a72680fc96fad194d74fe77a5d31f131eec",
+                "Comment": "Batched the retrieval of the project settings to avoid the 2100 parameter limit\n\nFixes https://github.com/OctopusDeploy/Issues/issues/6825\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-13T05:04:28.203+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.6.4855",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.6.4855",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-49-E3J4C",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87057",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87057/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87057/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87057/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87057",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-49-E3J4C",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-87057",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87057/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87057/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87057/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87057/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87057/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107741",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107741",
+            "TaskId": "ServerTasks-1482533",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T06:25:22.789+00:00",
+            "QueueTime": "2021-04-13T06:25:22.756+00:00",
+            "StartTime": "2021-04-13T06:25:23.551+00:00",
+            "CompletedTime": "2021-04-13T08:04:50.169+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "2 hours",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107741",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482533"
+            }
+          },
+          {
+            "Id": "Deployments-107718",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107718",
+            "TaskId": "ServerTasks-1482309",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T05:04:29.864+00:00",
+            "QueueTime": "2021-04-13T05:04:29.865+00:00",
+            "StartTime": "2021-04-13T05:06:15.152+00:00",
+            "CompletedTime": "2021-04-13T05:23:20.012+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "19 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107718",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482309"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107727",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107727",
+            "TaskId": "ServerTasks-1482404",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T05:41:06.028+00:00",
+            "QueueTime": "2021-04-13T05:41:05.998+00:00",
+            "StartTime": "2021-04-13T05:41:06.439+00:00",
+            "CompletedTime": "2021-04-13T06:23:53.031+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "43 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107727",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482404"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107742",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107742",
+            "TaskId": "ServerTasks-1482532",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T06:25:22.794+00:00",
+            "QueueTime": "2021-04-13T06:25:22.756+00:00",
+            "StartTime": "2021-04-13T06:25:23.427+00:00",
+            "CompletedTime": "2021-04-13T06:54:26.623+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "29 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107742",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482532"
+            }
+          }
+        ],
+        "Environments-2586": [
+          {
+            "Id": "Deployments-107770",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2586",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107770",
+            "TaskId": "ServerTasks-1482934",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T08:46:40.825+00:00",
+            "QueueTime": "2021-04-13T08:46:40.786+00:00",
+            "StartTime": "2021-04-13T08:46:41.334+00:00",
+            "CompletedTime": "2021-04-13T08:51:29.261+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "5 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107770",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482934"
+            }
+          }
+        ],
+        "Environments-2587": [
+          {
+            "Id": "Deployments-107779",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2587",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107779",
+            "TaskId": "ServerTasks-1483123",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T09:58:43.446+00:00",
+            "QueueTime": "2021-04-13T09:58:43.404+00:00",
+            "StartTime": "2021-04-13T09:58:44.113+00:00",
+            "CompletedTime": "2021-04-13T10:03:12.982+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "4 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107779",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483123"
+            }
+          }
+        ],
+        "Environments-2588": [
+          {
+            "Id": "Deployments-107781",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2588",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107781",
+            "TaskId": "ServerTasks-1483180",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T10:19:51.259+00:00",
+            "QueueTime": "2021-04-13T10:19:51.228+00:00",
+            "StartTime": "2021-04-13T10:19:51.707+00:00",
+            "CompletedTime": "2021-04-13T10:39:18.565+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "19 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107781",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483180"
+            }
+          }
+        ],
+        "Environments-2589": [
+          {
+            "Id": "Deployments-107787",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2589",
+            "ReleaseId": "Releases-87057",
+            "DeploymentId": "Deployments-107787",
+            "TaskId": "ServerTasks-1483244",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4855",
+            "Created": "2021-04-13T10:41:12.527+00:00",
+            "QueueTime": "2021-04-13T10:41:12.450+00:00",
+            "StartTime": "2021-04-13T10:41:12.946+00:00",
+            "CompletedTime": "2021-04-13T11:24:32.214+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "43 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107787",
+              "Release": "/api/Spaces-622/releases/Releases-87057",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1483244"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87049",
+        "Version": "2020.5.338",
+        "ChannelId": "Channels-4583",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.5.338",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.338",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2231073",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "Comment": "Removed duplicate project entry\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.5.338",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.338",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2231073",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2feaeb428e8488ce6c9681b1d87cbeee1a19ad5f",
+                "Comment": "Removed duplicate project entry\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-13T03:53:42.261+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.5.338",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.5.338",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87049",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87049/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87049/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87049/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87049",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-87049",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87049/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87049/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87049/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87049/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87049/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4583",
+        "Name": "Previous Release 2 - 2020.5",
+        "Description": "eg\n`2020.5.0-rc0003`\n`2020.5.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1668",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "2cd84d29-23d9-4f8f-9035-6e54a9041fa7",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "71275451-9c17-472d-9ea5-53a3568cf603",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4583",
+          "Releases": "/api/Spaces-622/channels/Channels-4583/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107710",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87049",
+            "DeploymentId": "Deployments-107710",
+            "TaskId": "ServerTasks-1482099",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.338",
+            "Created": "2021-04-13T03:53:42.605+00:00",
+            "QueueTime": "2021-04-13T03:53:42.605+00:00",
+            "StartTime": "2021-04-13T04:22:57.413+00:00",
+            "CompletedTime": "2021-04-13T04:31:51.295+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "38 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107710",
+              "Release": "/api/Spaces-622/releases/Releases-87049",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482099"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107747",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87049",
+            "DeploymentId": "Deployments-107747",
+            "TaskId": "ServerTasks-1482601",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.338",
+            "Created": "2021-04-13T06:50:45.099+00:00",
+            "QueueTime": "2021-04-13T06:50:45.068+00:00",
+            "StartTime": "2021-04-13T06:54:26.721+00:00",
+            "CompletedTime": "2021-04-13T07:14:13.591+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "23 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107747",
+              "Release": "/api/Spaces-622/releases/Releases-87049",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482601"
+            }
+          }
+        ],
+        "Environments-2589": [
+          {
+            "Id": "Deployments-107750",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2589",
+            "ReleaseId": "Releases-87049",
+            "DeploymentId": "Deployments-107750",
+            "TaskId": "ServerTasks-1482671",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.338",
+            "Created": "2021-04-13T07:14:51.341+00:00",
+            "QueueTime": "2021-04-13T07:14:51.314+00:00",
+            "StartTime": "2021-04-13T07:14:51.724+00:00",
+            "CompletedTime": "2021-04-13T07:40:01.885+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "25 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107750",
+              "Release": "/api/Spaces-622/releases/Releases-87049",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482671"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87019",
+        "Version": "2021.2.1808",
+        "ChannelId": "Channels-4946",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1808",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1808",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2229038",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "c42c8dc75996600bd4394b828a8d624758344511",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c42c8dc75996600bd4394b828a8d624758344511",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "c42c8dc75996600bd4394b828a8d624758344511",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c42c8dc75996600bd4394b828a8d624758344511",
+                "Comment": "Step UI: Package Selection support (#8595)\n\n* Step UI: Implemented the skeleton of a package selector\r\n\r\n* Step UI: Added ConfiguredProps to the PackageSelector component\r\n\r\n* Step UI: Mapped the runtime inputs for package selection\r\n\r\n* Step UI: Access to the package selection object in the PackageSelection control\r\n\r\n* Step UI: Pass through some required dependencies of package selection\r\n\r\n* Actually return the result of rendering the package selector\r\n\r\n* Wired up all of the package selector dependencies\r\n\r\n* Step UI: Implemented a basic summary for package selection\r\n\r\n* Step UI: Polishing the API for package selection\r\n\r\n* Improve the package selection summary\r\n\r\n* Ensure that we set the packages property on actions"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1808",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1808",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2229038",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "c42c8dc75996600bd4394b828a8d624758344511",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c42c8dc75996600bd4394b828a8d624758344511",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "c42c8dc75996600bd4394b828a8d624758344511",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/c42c8dc75996600bd4394b828a8d624758344511",
+                "Comment": "Step UI: Package Selection support (#8595)\n\n* Step UI: Implemented the skeleton of a package selector\r\n\r\n* Step UI: Added ConfiguredProps to the PackageSelector component\r\n\r\n* Step UI: Mapped the runtime inputs for package selection\r\n\r\n* Step UI: Access to the package selection object in the PackageSelection control\r\n\r\n* Step UI: Pass through some required dependencies of package selection\r\n\r\n* Actually return the result of rendering the package selector\r\n\r\n* Wired up all of the package selector dependencies\r\n\r\n* Step UI: Implemented a basic summary for package selection\r\n\r\n* Step UI: Polishing the API for package selection\r\n\r\n* Improve the package selection summary\r\n\r\n* Ensure that we set the packages property on actions"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-12T23:13:25.419+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1808",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1808",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87019",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87019/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87019/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87019/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87019",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-87019",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87019/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87019/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87019/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87019/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87019/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107669",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87019",
+            "DeploymentId": "Deployments-107669",
+            "TaskId": "ServerTasks-1481303",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1808",
+            "Created": "2021-04-12T23:13:25.796+00:00",
+            "QueueTime": "2021-04-12T23:13:25.796+00:00",
+            "StartTime": "2021-04-12T23:13:26.278+00:00",
+            "CompletedTime": "2021-04-12T23:33:37.200+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "20 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107669",
+              "Release": "/api/Spaces-622/releases/Releases-87019",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481303"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107671",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87019",
+            "DeploymentId": "Deployments-107671",
+            "TaskId": "ServerTasks-1481363",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1808",
+            "Created": "2021-04-12T23:35:09.605+00:00",
+            "QueueTime": "2021-04-12T23:35:09.571+00:00",
+            "StartTime": "2021-04-12T23:35:09.998+00:00",
+            "CompletedTime": "2021-04-13T00:07:51.329+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "33 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107671",
+              "Release": "/api/Spaces-622/releases/Releases-87019",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481363"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107676",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87019",
+            "DeploymentId": "Deployments-107676",
+            "TaskId": "ServerTasks-1481473",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1808",
+            "Created": "2021-04-13T00:08:53.195+00:00",
+            "QueueTime": "2021-04-13T00:08:53.150+00:00",
+            "StartTime": "2021-04-13T00:08:53.842+00:00",
+            "CompletedTime": "2021-04-13T00:20:26.963+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "12 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107676",
+              "Release": "/api/Spaces-622/releases/Releases-87019",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481473"
+            }
+          }
+        ],
+        "Environments-2584": [
+          {
+            "Id": "Deployments-107879",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2584",
+            "ReleaseId": "Releases-87019",
+            "DeploymentId": "Deployments-107879",
+            "TaskId": "ServerTasks-1485547",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1808",
+            "Created": "2021-04-14T00:20:59.010+00:00",
+            "QueueTime": "2021-04-14T00:20:58.977+00:00",
+            "StartTime": "2021-04-14T00:21:00.698+00:00",
+            "CompletedTime": "2021-04-14T00:25:28.588+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "4 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107879",
+              "Release": "/api/Spaces-622/releases/Releases-87019",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1485547"
+            }
+          }
+        ],
+        "Environments-2585": [
+          {
+            "Id": "Deployments-107882",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2585",
+            "ReleaseId": "Releases-87019",
+            "DeploymentId": "Deployments-107882",
+            "TaskId": "ServerTasks-1485563",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1808",
+            "Created": "2021-04-14T00:27:28.441+00:00",
+            "QueueTime": "2021-04-14T00:27:28.406+00:00",
+            "StartTime": "2021-04-14T00:27:28.942+00:00",
+            "CompletedTime": "2021-04-14T00:27:47.685+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "19 seconds",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107882",
+              "Release": "/api/Spaces-622/releases/Releases-87019",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1485563"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87017",
+        "Version": "2021.1.6969",
+        "ChannelId": "Channels-4448",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.1.6969",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6969",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2228680",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.1.6969",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6969",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2228680",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-12T22:08:10.996+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.1.6969",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.1.6969",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87017",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87017/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87017/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87017/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87017",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-87017",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87017/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87017/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87017/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87017/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87017/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4448",
+        "Name": "Latest Release - 2021.1",
+        "Description": "eg: `2021.1.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1667",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "86bac821-0539-4f15-8ea3-939136619188",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "af112c81-e23f-490b-8bf9-7e9145268acd",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4448",
+          "Releases": "/api/Spaces-622/channels/Channels-4448/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107665",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87017",
+            "DeploymentId": "Deployments-107665",
+            "TaskId": "ServerTasks-1481130",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6969",
+            "Created": "2021-04-12T22:08:11.336+00:00",
+            "QueueTime": "2021-04-12T22:08:11.336+00:00",
+            "StartTime": "2021-04-12T22:22:38.311+00:00",
+            "CompletedTime": "2021-04-12T22:40:11.670+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "32 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107665",
+              "Release": "/api/Spaces-622/releases/Releases-87017",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481130"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107668",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-87017",
+            "DeploymentId": "Deployments-107668",
+            "TaskId": "ServerTasks-1481211",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6969",
+            "Created": "2021-04-12T22:40:23.578+00:00",
+            "QueueTime": "2021-04-12T22:40:23.539+00:00",
+            "StartTime": "2021-04-12T22:40:23.945+00:00",
+            "CompletedTime": "2021-04-12T23:17:49.764+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "37 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107668",
+              "Release": "/api/Spaces-622/releases/Releases-87017",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481211"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107670",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87017",
+            "DeploymentId": "Deployments-107670",
+            "TaskId": "ServerTasks-1481319",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6969",
+            "Created": "2021-04-12T23:18:45.168+00:00",
+            "QueueTime": "2021-04-12T23:18:45.137+00:00",
+            "StartTime": "2021-04-12T23:18:45.656+00:00",
+            "CompletedTime": "2021-04-12T23:27:30.784+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "9 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107670",
+              "Release": "/api/Spaces-622/releases/Releases-87017",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481319"
+            }
+          }
+        ],
+        "Environments-2584": [
+          {
+            "Id": "Deployments-107868",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2584",
+            "ReleaseId": "Releases-87017",
+            "DeploymentId": "Deployments-107868",
+            "TaskId": "ServerTasks-1485384",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6969",
+            "Created": "2021-04-13T23:29:12.885+00:00",
+            "QueueTime": "2021-04-13T23:29:12.843+00:00",
+            "StartTime": "2021-04-13T23:29:13.276+00:00",
+            "CompletedTime": "2021-04-13T23:39:36.176+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "10 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107868",
+              "Release": "/api/Spaces-622/releases/Releases-87017",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1485384"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2586"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-87015",
+        "Version": "2020.5.337",
+        "ChannelId": "Channels-4583",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.5.337",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.337",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2228437",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "90de8686d561e88ebd125536c3c6e30e0e81a579",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/90de8686d561e88ebd125536c3c6e30e0e81a579",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.5.337",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.5.337",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2228437",
+            "Branch": "refs/heads/release/2020.5",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "90de8686d561e88ebd125536c3c6e30e0e81a579",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/90de8686d561e88ebd125536c3c6e30e0e81a579",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-12T21:40:25.465+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.5.337",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.5.337",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-87015",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-87015/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-87015/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-87015/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-87015",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-87015",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-87015/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-87015/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-87015/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-87015/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-87015/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4583",
+        "Name": "Previous Release 2 - 2020.5",
+        "Description": "eg\n`2020.5.0-rc0003`\n`2020.5.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1668",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "2cd84d29-23d9-4f8f-9035-6e54a9041fa7",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "71275451-9c17-472d-9ea5-53a3568cf603",
+            "VersionRange": "[2020.5.0-a,2020.5.99999)",
+            "Tag": "^rc\\d*$|^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4583",
+          "Releases": "/api/Spaces-622/channels/Channels-4583/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107662",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-87015",
+            "DeploymentId": "Deployments-107662",
+            "TaskId": "ServerTasks-1481056",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.337",
+            "Created": "2021-04-12T21:40:25.857+00:00",
+            "QueueTime": "2021-04-12T21:40:25.857+00:00",
+            "StartTime": "2021-04-12T21:40:26.362+00:00",
+            "CompletedTime": "2021-04-12T21:50:41.117+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "10 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107662",
+              "Release": "/api/Spaces-622/releases/Releases-87015",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481056"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107663",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-87015",
+            "DeploymentId": "Deployments-107663",
+            "TaskId": "ServerTasks-1481084",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.337",
+            "Created": "2021-04-12T21:51:26.494+00:00",
+            "QueueTime": "2021-04-12T21:51:26.462+00:00",
+            "StartTime": "2021-04-12T21:51:26.939+00:00",
+            "CompletedTime": "2021-04-12T22:12:23.622+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "21 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107663",
+              "Release": "/api/Spaces-622/releases/Releases-87015",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481084"
+            }
+          }
+        ],
+        "Environments-2589": [
+          {
+            "Id": "Deployments-107666",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2589",
+            "ReleaseId": "Releases-87015",
+            "DeploymentId": "Deployments-107666",
+            "TaskId": "ServerTasks-1481145",
+            "TenantId": null,
+            "ChannelId": "Channels-4583",
+            "ReleaseVersion": "2020.5.337",
+            "Created": "2021-04-12T22:13:02.369+00:00",
+            "QueueTime": "2021-04-12T22:13:02.338+00:00",
+            "StartTime": "2021-04-12T22:13:02.789+00:00",
+            "CompletedTime": "2021-04-12T22:50:56.012+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "38 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107666",
+              "Release": "/api/Spaces-622/releases/Releases-87015",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1481145"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-86890",
+        "Version": "2021.1.6966",
+        "ChannelId": "Channels-4448",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.1.6966",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6966",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2220052",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+                "Comment": "Update dev time portal version to 2021.1.6963\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.1.6966",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.1.6966",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2220052",
+            "Branch": "refs/heads/release/2021.1",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/4ee6e447dfba359a3d98d9a22b048052c6671b6d",
+                "Comment": "Update dev time portal version to 2021.1.6963\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-11T22:10:46.669+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.1.6966",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.1.6966",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-86890",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-86890/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-86890/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-86890/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-86890",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-86890",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-86890/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-86890/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-86890/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-86890/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-86890/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4448",
+        "Name": "Latest Release - 2021.1",
+        "Description": "eg: `2021.1.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1667",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "86bac821-0539-4f15-8ea3-939136619188",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "af112c81-e23f-490b-8bf9-7e9145268acd",
+            "VersionRange": "[2021.1.0-a,2021.1.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4448",
+          "Releases": "/api/Spaces-622/channels/Channels-4448/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-107496",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-86890",
+            "DeploymentId": "Deployments-107496",
+            "TaskId": "ServerTasks-1477183",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6966",
+            "Created": "2021-04-11T22:10:47.193+00:00",
+            "QueueTime": "2021-04-11T22:10:47.194+00:00",
+            "StartTime": "2021-04-11T22:10:47.677+00:00",
+            "CompletedTime": "2021-04-11T22:29:46.474+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "19 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107496",
+              "Release": "/api/Spaces-622/releases/Releases-86890",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1477183"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-107522",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-86890",
+            "DeploymentId": "Deployments-107522",
+            "TaskId": "ServerTasks-1477864",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6966",
+            "Created": "2021-04-12T02:07:08.263+00:00",
+            "QueueTime": "2021-04-12T02:07:08.220+00:00",
+            "StartTime": "2021-04-12T03:58:52.268+00:00",
+            "CompletedTime": "2021-04-12T05:09:33.528+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "3 hours",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107522",
+              "Release": "/api/Spaces-622/releases/Releases-86890",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1477864"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-107549",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-86890",
+            "DeploymentId": "Deployments-107549",
+            "TaskId": "ServerTasks-1478324",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6966",
+            "Created": "2021-04-12T05:10:47.839+00:00",
+            "QueueTime": "2021-04-12T05:10:47.804+00:00",
+            "StartTime": "2021-04-12T05:10:48.283+00:00",
+            "CompletedTime": "2021-04-12T05:23:17.499+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "12 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107549",
+              "Release": "/api/Spaces-622/releases/Releases-86890",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1478324"
+            }
+          }
+        ],
+        "Environments-2584": [
+          {
+            "Id": "Deployments-107749",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2584",
+            "ReleaseId": "Releases-86890",
+            "DeploymentId": "Deployments-107749",
+            "TaskId": "ServerTasks-1482603",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6966",
+            "Created": "2021-04-13T06:50:52.172+00:00",
+            "QueueTime": "2021-04-13T06:50:52.120+00:00",
+            "StartTime": "2021-04-13T06:50:52.683+00:00",
+            "CompletedTime": "2021-04-13T07:54:19.355+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "1 hour",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107749",
+              "Release": "/api/Spaces-622/releases/Releases-86890",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1482603"
+            }
+          }
+        ],
+        "Environments-2586": [
+          {
+            "Id": "Deployments-107952",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2586",
+            "ReleaseId": "Releases-86890",
+            "DeploymentId": "Deployments-107952",
+            "TaskId": "ServerTasks-1486462",
+            "TenantId": null,
+            "ChannelId": "Channels-4448",
+            "ReleaseVersion": "2021.1.6966",
+            "Created": "2021-04-14T07:55:01.565+00:00",
+            "QueueTime": "2021-04-14T07:55:01.538+00:00",
+            "StartTime": "2021-04-14T07:55:02.044+00:00",
+            "CompletedTime": "2021-04-14T08:05:02.609+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "10 minutes",
+            "IsCurrent": true,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107952",
+              "Release": "/api/Spaces-622/releases/Releases-86890",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1486462"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2587"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-86368",
+        "Version": "2020.6.4817",
+        "ChannelId": "Channels-4847",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.6.4817",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4817",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2196941",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "045d7449d75a6a5af98968d8e7205b7a16101df5",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/045d7449d75a6a5af98968d8e7205b7a16101df5",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "045d7449d75a6a5af98968d8e7205b7a16101df5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/045d7449d75a6a5af98968d8e7205b7a16101df5",
+                "Comment": "Update dev time portal version to 2020.6.4809\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.6.4817",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4817",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2196941",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "045d7449d75a6a5af98968d8e7205b7a16101df5",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/045d7449d75a6a5af98968d8e7205b7a16101df5",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "045d7449d75a6a5af98968d8e7205b7a16101df5",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/045d7449d75a6a5af98968d8e7205b7a16101df5",
+                "Comment": "Update dev time portal version to 2020.6.4809\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-04-04T21:43:30.734+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.6.4817",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.6.4817",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-86368",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-86368/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-86368/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-86368/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-86368",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-86368",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-86368/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-86368/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-86368/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-86368/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-86368/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-106798",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-86368",
+            "DeploymentId": "Deployments-106798",
+            "TaskId": "ServerTasks-1449391",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4817",
+            "Created": "2021-04-04T21:43:31.101+00:00",
+            "QueueTime": "2021-04-04T21:43:31.102+00:00",
+            "StartTime": "2021-04-04T21:43:31.647+00:00",
+            "CompletedTime": "2021-04-04T22:03:21.285+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "20 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106798",
+              "Release": "/api/Spaces-622/releases/Releases-86368",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1449391"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-106802",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-86368",
+            "DeploymentId": "Deployments-106802",
+            "TaskId": "ServerTasks-1449454",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4817",
+            "Created": "2021-04-04T22:04:57.185+00:00",
+            "QueueTime": "2021-04-04T22:04:57.107+00:00",
+            "StartTime": "2021-04-04T22:04:57.592+00:00",
+            "CompletedTime": "2021-04-04T23:04:19.832+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "59 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106802",
+              "Release": "/api/Spaces-622/releases/Releases-86368",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1449454"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-106809",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-86368",
+            "DeploymentId": "Deployments-106809",
+            "TaskId": "ServerTasks-1449623",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4817",
+            "Created": "2021-04-04T23:04:58.318+00:00",
+            "QueueTime": "2021-04-04T23:04:58.287+00:00",
+            "StartTime": "2021-04-04T23:04:58.700+00:00",
+            "CompletedTime": "2021-04-04T23:27:37.801+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "23 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106809",
+              "Release": "/api/Spaces-622/releases/Releases-86368",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1449623"
+            }
+          }
+        ],
+        "Environments-2586": [
+          {
+            "Id": "Deployments-106813",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2586",
+            "ReleaseId": "Releases-86368",
+            "DeploymentId": "Deployments-106813",
+            "TaskId": "ServerTasks-1449707",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4817",
+            "Created": "2021-04-04T23:28:58.902+00:00",
+            "QueueTime": "2021-04-04T23:28:58.865+00:00",
+            "StartTime": "2021-04-04T23:28:59.235+00:00",
+            "CompletedTime": "2021-04-04T23:32:06.623+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "3 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106813",
+              "Release": "/api/Spaces-622/releases/Releases-86368",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1449707"
+            }
+          }
+        ],
+        "Environments-2587": [
+          {
+            "Id": "Deployments-107525",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2587",
+            "ReleaseId": "Releases-86368",
+            "DeploymentId": "Deployments-107525",
+            "TaskId": "ServerTasks-1477867",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4817",
+            "Created": "2021-04-12T02:07:18.995+00:00",
+            "QueueTime": "2021-04-12T02:07:18.946+00:00",
+            "StartTime": "2021-04-12T02:07:19.379+00:00",
+            "CompletedTime": "2021-04-12T02:23:26.116+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "16 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107525",
+              "Release": "/api/Spaces-622/releases/Releases-86368",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1477867"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [
+        "Environments-2588"
+      ],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-86263",
+        "Version": "2020.6.4809",
+        "ChannelId": "Channels-4847",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2020.6.4809",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4809",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2193081",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "3b393f23b33a7402f2c63eac7bd59644c84fb11b",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3b393f23b33a7402f2c63eac7bd59644c84fb11b",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2020.6.4809",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2020.6.4809",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2193081",
+            "Branch": "refs/heads/release/2020.6",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "3b393f23b33a7402f2c63eac7bd59644c84fb11b",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3b393f23b33a7402f2c63eac7bd59644c84fb11b",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": []
+          }
+        ],
+        "Assembled": "2021-04-01T21:40:21.222+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2020.6.4809",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2020.6.4809",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-86263",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-86263/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-86263/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-86263/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-86263",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-86263",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-86263/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-86263/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-86263/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-86263/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-86263/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4847",
+        "Name": "Previous Release - 2020.6",
+        "Description": "eg\n`2020.6.0-rc0003`\n`2020.6.0`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1669",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "dde4af0b-2c4b-47ea-93ec-184210f07054",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "e5b2cd67-664e-4cc2-9030-762a9bda2408",
+            "VersionRange": "[2020.6.0-a,2020.6.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4847",
+          "Releases": "/api/Spaces-622/channels/Channels-4847/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-106646",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-106646",
+            "TaskId": "ServerTasks-1438074",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-01T21:40:21.792+00:00",
+            "QueueTime": "2021-04-01T21:40:21.793+00:00",
+            "StartTime": "2021-04-01T21:40:22.343+00:00",
+            "CompletedTime": "2021-04-01T22:00:08.994+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "20 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106646",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1438074"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-106650",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-106650",
+            "TaskId": "ServerTasks-1438131",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-01T22:01:24.592+00:00",
+            "QueueTime": "2021-04-01T22:01:24.555+00:00",
+            "StartTime": "2021-04-01T22:01:25.124+00:00",
+            "CompletedTime": "2021-04-01T22:35:53.657+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "34 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106650",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1438131"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-106653",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-106653",
+            "TaskId": "ServerTasks-1438219",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-01T22:37:05.889+00:00",
+            "QueueTime": "2021-04-01T22:37:05.856+00:00",
+            "StartTime": "2021-04-01T22:37:06.425+00:00",
+            "CompletedTime": "2021-04-01T23:13:39.287+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "37 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106653",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1438219"
+            }
+          }
+        ],
+        "Environments-2586": [
+          {
+            "Id": "Deployments-106660",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2586",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-106660",
+            "TaskId": "ServerTasks-1438933",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-02T03:08:22.626+00:00",
+            "QueueTime": "2021-04-02T03:08:22.589+00:00",
+            "StartTime": "2021-04-02T03:08:23.100+00:00",
+            "CompletedTime": "2021-04-02T03:25:49.990+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "17 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106660",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1438933"
+            }
+          }
+        ],
+        "Environments-2587": [
+          {
+            "Id": "Deployments-106801",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2587",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-106801",
+            "TaskId": "ServerTasks-1449445",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-04T22:01:33.969+00:00",
+            "QueueTime": "2021-04-04T22:01:33.939+00:00",
+            "StartTime": "2021-04-04T22:01:34.314+00:00",
+            "CompletedTime": "2021-04-04T22:05:20.431+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "4 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106801",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1449445"
+            }
+          }
+        ],
+        "Environments-2588": [
+          {
+            "Id": "Deployments-107520",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2588",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-107520",
+            "TaskId": "ServerTasks-1477862",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-12T02:07:01.478+00:00",
+            "QueueTime": "2021-04-12T02:07:01.438+00:00",
+            "StartTime": "2021-04-12T02:07:01.879+00:00",
+            "CompletedTime": "2021-04-12T02:23:11.039+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "16 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107520",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1477862"
+            }
+          }
+        ],
+        "Environments-2589": [
+          {
+            "Id": "Deployments-107527",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2589",
+            "ReleaseId": "Releases-86263",
+            "DeploymentId": "Deployments-107527",
+            "TaskId": "ServerTasks-1477912",
+            "TenantId": null,
+            "ChannelId": "Channels-4847",
+            "ReleaseVersion": "2020.6.4809",
+            "Created": "2021-04-12T02:25:02.196+00:00",
+            "QueueTime": "2021-04-12T02:25:02.164+00:00",
+            "StartTime": "2021-04-12T02:25:02.587+00:00",
+            "CompletedTime": "2021-04-12T02:54:27.973+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "29 minutes",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-107527",
+              "Release": "/api/Spaces-622/releases/Releases-86263",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1477912"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    },
+    {
+      "Release": {
+        "Id": "Releases-85683",
+        "Version": "2021.2.1033",
+        "ChannelId": "Channels-4946",
+        "ReleaseNotes": "",
+        "ProjectDeploymentProcessSnapshotId": "deploymentprocess-Projects-4224-s-202-RED6U",
+        "IgnoreChannelRules": false,
+        "BuildInformation": [
+          {
+            "PackageId": "Octopus.Installers",
+            "Version": "2021.2.1033",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1033",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2167774",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b2aafd360c682187115d298978b104bad6ca15e7",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b2aafd360c682187115d298978b104bad6ca15e7",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "b2aafd360c682187115d298978b104bad6ca15e7",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b2aafd360c682187115d298978b104bad6ca15e7",
+                "Comment": "Merge pull request #8506 from OctopusDeploy/gold/amc/migrate-index-responders\n\nMigrate - Remaining IndexResponder endpoints"
+              },
+              {
+                "Id": "8166bfd32f46aec435546c92947432d0de7e741e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/8166bfd32f46aec435546c92947432d0de7e741e",
+                "Comment": "Merge pull request #8515 from OctopusDeploy/bug/restart-test-timeout-each-action\n\nRestart eventual assertion timeout each time an action is performed."
+              },
+              {
+                "Id": "87a24e5d1788fb576bec9e4b979efe43e41bc94e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/87a24e5d1788fb576bec9e4b979efe43e41bc94e",
+                "Comment": "Merge pull request #8501 from OctopusDeploy/andrewh/async-method-conventions\n\nAdd async method convention tests"
+              },
+              {
+                "Id": "468e47278ec97bf59581d633cdf837839a0afced",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/468e47278ec97bf59581d633cdf837839a0afced",
+                "Comment": "Resolving merge conflict\n"
+              },
+              {
+                "Id": "05bf235447b83179b78239ead012bb1dca45bfbb",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/05bf235447b83179b78239ead012bb1dca45bfbb",
+                "Comment": "Rework to use injected CancellationToken on controller action methods (#8499)\n\n* Replaced usages of HttpContext.RequestAborted with injected CancellationToken\r\n\r\n* Added a convention test around usage of CancellationTokens. Corrected usage of CancellationTokens in numerous places."
+              },
+              {
+                "Id": "e6a92fd6c2698e45977ebef4c484515ef6cfd2ed",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e6a92fd6c2698e45977ebef4c484515ef6cfd2ed",
+                "Comment": "Restart eventual assertion timeout each time an action is performed.\n"
+              },
+              {
+                "Id": "69b2677a7eb6e4d091533828ff582b5663fee748",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/69b2677a7eb6e4d091533828ff582b5663fee748",
+                "Comment": "Merge pull request #8502 from OctopusDeploy/gold/pg/revert-allasync\n\nRevert allsync overload in IDocumentStore"
+              },
+              {
+                "Id": "f54cd4c7fa17d85a6abb7afeddd19596c0a1ad26",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/f54cd4c7fa17d85a6abb7afeddd19596c0a1ad26",
+                "Comment": "Make tests more clear; make changes to make them pass.\n"
+              },
+              {
+                "Id": "a21f4ee9b7d428b624568eca7cc4718ffd3becba",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a21f4ee9b7d428b624568eca7cc4718ffd3becba",
+                "Comment": "Add async method convention tests. Currently failing; many to tidy.\n"
+              },
+              {
+                "Id": "2af330d274a0918c7e2d0ce85a7f57ff6bd30080",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2af330d274a0918c7e2d0ce85a7f57ff6bd30080",
+                "Comment": "remove allasync that exposes sql via interface\n"
+              },
+              {
+                "Id": "5117386a1cfb387434c0f15f83aa7b85c0f3954b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/5117386a1cfb387434c0f15f83aa7b85c0f3954b",
+                "Comment": "Update approvals\n"
+              },
+              {
+                "Id": "9efd1a3246e74902ff0c153c4413cab8b4361a05",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/9efd1a3246e74902ff0c153c4413cab8b4361a05",
+                "Comment": "Migrate GET /communityactiontemplates\n"
+              },
+              {
+                "Id": "b9d56ceced3f83e67b19a906cf24e15d2a883071",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b9d56ceced3f83e67b19a906cf24e15d2a883071",
+                "Comment": "Migrate GET /runbookSnapshots\n"
+              },
+              {
+                "Id": "3de67aac8399c6a8515b529e98cc41293748f266",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3de67aac8399c6a8515b529e98cc41293748f266",
+                "Comment": "Migrate GET /runbookProcesses\n"
+              }
+            ]
+          },
+          {
+            "PackageId": "OctopusDeploy",
+            "Version": "2021.2.1033",
+            "BuildEnvironment": "TeamCity",
+            "BuildNumber": "2021.2.1033",
+            "BuildUrl": "https://build.octopushq.com/viewLog.html?buildId=2167774",
+            "Branch": "refs/heads/master",
+            "VcsType": "Git",
+            "VcsRoot": "https://github.com/OctopusDeploy/OctopusDeploy",
+            "VcsCommitNumber": "b2aafd360c682187115d298978b104bad6ca15e7",
+            "VcsCommitUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b2aafd360c682187115d298978b104bad6ca15e7",
+            "IssueTrackerName": null,
+            "WorkItems": [],
+            "Commits": [
+              {
+                "Id": "b2aafd360c682187115d298978b104bad6ca15e7",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b2aafd360c682187115d298978b104bad6ca15e7",
+                "Comment": "Merge pull request #8506 from OctopusDeploy/gold/amc/migrate-index-responders\n\nMigrate - Remaining IndexResponder endpoints"
+              },
+              {
+                "Id": "8166bfd32f46aec435546c92947432d0de7e741e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/8166bfd32f46aec435546c92947432d0de7e741e",
+                "Comment": "Merge pull request #8515 from OctopusDeploy/bug/restart-test-timeout-each-action\n\nRestart eventual assertion timeout each time an action is performed."
+              },
+              {
+                "Id": "87a24e5d1788fb576bec9e4b979efe43e41bc94e",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/87a24e5d1788fb576bec9e4b979efe43e41bc94e",
+                "Comment": "Merge pull request #8501 from OctopusDeploy/andrewh/async-method-conventions\n\nAdd async method convention tests"
+              },
+              {
+                "Id": "468e47278ec97bf59581d633cdf837839a0afced",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/468e47278ec97bf59581d633cdf837839a0afced",
+                "Comment": "Resolving merge conflict\n"
+              },
+              {
+                "Id": "05bf235447b83179b78239ead012bb1dca45bfbb",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/05bf235447b83179b78239ead012bb1dca45bfbb",
+                "Comment": "Rework to use injected CancellationToken on controller action methods (#8499)\n\n* Replaced usages of HttpContext.RequestAborted with injected CancellationToken\r\n\r\n* Added a convention test around usage of CancellationTokens. Corrected usage of CancellationTokens in numerous places."
+              },
+              {
+                "Id": "e6a92fd6c2698e45977ebef4c484515ef6cfd2ed",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/e6a92fd6c2698e45977ebef4c484515ef6cfd2ed",
+                "Comment": "Restart eventual assertion timeout each time an action is performed.\n"
+              },
+              {
+                "Id": "69b2677a7eb6e4d091533828ff582b5663fee748",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/69b2677a7eb6e4d091533828ff582b5663fee748",
+                "Comment": "Merge pull request #8502 from OctopusDeploy/gold/pg/revert-allasync\n\nRevert allsync overload in IDocumentStore"
+              },
+              {
+                "Id": "f54cd4c7fa17d85a6abb7afeddd19596c0a1ad26",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/f54cd4c7fa17d85a6abb7afeddd19596c0a1ad26",
+                "Comment": "Make tests more clear; make changes to make them pass.\n"
+              },
+              {
+                "Id": "a21f4ee9b7d428b624568eca7cc4718ffd3becba",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/a21f4ee9b7d428b624568eca7cc4718ffd3becba",
+                "Comment": "Add async method convention tests. Currently failing; many to tidy.\n"
+              },
+              {
+                "Id": "2af330d274a0918c7e2d0ce85a7f57ff6bd30080",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/2af330d274a0918c7e2d0ce85a7f57ff6bd30080",
+                "Comment": "remove allasync that exposes sql via interface\n"
+              },
+              {
+                "Id": "5117386a1cfb387434c0f15f83aa7b85c0f3954b",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/5117386a1cfb387434c0f15f83aa7b85c0f3954b",
+                "Comment": "Update approvals\n"
+              },
+              {
+                "Id": "9efd1a3246e74902ff0c153c4413cab8b4361a05",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/9efd1a3246e74902ff0c153c4413cab8b4361a05",
+                "Comment": "Migrate GET /communityactiontemplates\n"
+              },
+              {
+                "Id": "b9d56ceced3f83e67b19a906cf24e15d2a883071",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/b9d56ceced3f83e67b19a906cf24e15d2a883071",
+                "Comment": "Migrate GET /runbookSnapshots\n"
+              },
+              {
+                "Id": "3de67aac8399c6a8515b529e98cc41293748f266",
+                "LinkUrl": "https://github.com/OctopusDeploy/OctopusDeploy/commit/3de67aac8399c6a8515b529e98cc41293748f266",
+                "Comment": "Migrate GET /runbookProcesses\n"
+              }
+            ]
+          }
+        ],
+        "Assembled": "2021-03-26T02:22:46.433+00:00",
+        "ProjectId": "Projects-4224",
+        "LibraryVariableSetSnapshotIds": [
+          "variableset-LibraryVariableSets-921-s-2-VPUL3"
+        ],
+        "SelectedPackages": [
+          {
+            "StepName": "Upload Windows Installers to S3 for direct download",
+            "ActionName": "Upload Windows Installers to S3 for direct download",
+            "Version": "2021.2.1033",
+            "PackageReferenceName": "S3SourcePackage"
+          },
+          {
+            "StepName": "Push package to Chocolatey",
+            "ActionName": "Push package to Chocolatey",
+            "Version": "2021.2.1033",
+            "PackageReferenceName": "NuGetPush.Source.Package"
+          }
+        ],
+        "ProjectVariableSetSnapshotId": "variableset-Projects-4224-s-48-RVKH9",
+        "VersionControlReference": {
+          "GitRef": null,
+          "GitCommit": null
+        },
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/releases/Releases-85683",
+          "Project": "/api/Spaces-622/projects/Projects-4224",
+          "Progression": "/api/Spaces-622/releases/Releases-85683/progression",
+          "Deployments": "/api/Spaces-622/releases/Releases-85683/deployments{?skip,take}",
+          "DeploymentTemplate": "/api/Spaces-622/releases/Releases-85683/deployments/template",
+          "Artifacts": "/api/Spaces-622/artifacts?regarding=Releases-85683",
+          "ProjectVariableSnapshot": "/api/Spaces-622/variables/variableset-Projects-4224-s-48-RVKH9",
+          "ProjectDeploymentProcessSnapshot": "/api/Spaces-622/deploymentprocesses/deploymentprocess-Projects-4224-s-202-RED6U",
+          "Web": "/app#/Spaces-622/releases/Releases-85683",
+          "SnapshotVariables": "/api/Spaces-622/releases/Releases-85683/snapshot-variables",
+          "Defects": "/api/Spaces-622/releases/Releases-85683/defects",
+          "ReportDefect": "/api/Spaces-622/releases/Releases-85683/defects",
+          "ResolveDefect": "/api/Spaces-622/releases/Releases-85683/defects/resolve",
+          "DeploymentPreviews": "/api/Spaces-622/releases/Releases-85683/deployments/previews/"
+        }
+      },
+      "Channel": {
+        "Id": "Channels-4946",
+        "Name": "Current Dev - 2021.2",
+        "Description": "eg: `2021.2.6701`",
+        "ProjectId": "Projects-4224",
+        "LifecycleId": "Lifecycles-1670",
+        "IsDefault": false,
+        "Rules": [
+          {
+            "Id": "0486633b-683a-4257-a624-c314347f1c2b",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Push package to Chocolatey",
+                "PackageReference": "NuGetPush.Source.Package"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Push package to Chocolatey"
+            ]
+          },
+          {
+            "Id": "8c693366-7547-49d4-afdc-41235dd4d7a5",
+            "VersionRange": "[2021.2.0-a,2021.2.99999)",
+            "Tag": "^$",
+            "ActionPackages": [
+              {
+                "DeploymentAction": "Upload Windows Installers to S3 for direct download",
+                "PackageReference": "S3SourcePackage"
+              }
+            ],
+            "Links": {},
+            "Actions": [
+              "Upload Windows Installers to S3 for direct download"
+            ]
+          }
+        ],
+        "TenantTags": [],
+        "SpaceId": "Spaces-622",
+        "Links": {
+          "Self": "/api/Spaces-622/channels/Channels-4946",
+          "Releases": "/api/Spaces-622/channels/Channels-4946/releases{?skip,take,searchByVersion}",
+          "Project": "/api/Spaces-622/projects/Projects-4224"
+        }
+      },
+      "Deployments": {
+        "Environments-2583": [
+          {
+            "Id": "Deployments-105855",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2583",
+            "ReleaseId": "Releases-85683",
+            "DeploymentId": "Deployments-105855",
+            "TaskId": "ServerTasks-1411687",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1033",
+            "Created": "2021-03-26T02:22:46.997+00:00",
+            "QueueTime": "2021-03-26T02:22:46.998+00:00",
+            "StartTime": "2021-03-26T02:22:47.652+00:00",
+            "CompletedTime": "2021-03-26T02:36:54.536+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": true,
+            "ErrorMessage": "",
+            "Duration": "14 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-105855",
+              "Release": "/api/Spaces-622/releases/Releases-85683",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1411687"
+            }
+          }
+        ],
+        "Environments-2621": [
+          {
+            "Id": "Deployments-105857",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2621",
+            "ReleaseId": "Releases-85683",
+            "DeploymentId": "Deployments-105857",
+            "TaskId": "ServerTasks-1411726",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1033",
+            "Created": "2021-03-26T02:37:38.116+00:00",
+            "QueueTime": "2021-03-26T02:37:38.073+00:00",
+            "StartTime": "2021-03-26T02:37:38.557+00:00",
+            "CompletedTime": "2021-03-26T03:12:32.558+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "35 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-105857",
+              "Release": "/api/Spaces-622/releases/Releases-85683",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1411726"
+            }
+          }
+        ],
+        "Environments-2601": [
+          {
+            "Id": "Deployments-105859",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2601",
+            "ReleaseId": "Releases-85683",
+            "DeploymentId": "Deployments-105859",
+            "TaskId": "ServerTasks-1411820",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1033",
+            "Created": "2021-03-26T03:12:55.345+00:00",
+            "QueueTime": "2021-03-26T03:12:55.295+00:00",
+            "StartTime": "2021-03-26T03:12:56.047+00:00",
+            "CompletedTime": "2021-03-26T03:16:44.275+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "4 minutes",
+            "IsCurrent": false,
+            "IsPrevious": false,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-105859",
+              "Release": "/api/Spaces-622/releases/Releases-85683",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1411820"
+            }
+          }
+        ],
+        "Environments-2584": [
+          {
+            "Id": "Deployments-106084",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2584",
+            "ReleaseId": "Releases-85683",
+            "DeploymentId": "Deployments-106084",
+            "TaskId": "ServerTasks-1422595",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1033",
+            "Created": "2021-03-28T22:02:01.539+00:00",
+            "QueueTime": "2021-03-28T22:02:01.497+00:00",
+            "StartTime": "2021-03-28T22:02:02.167+00:00",
+            "CompletedTime": "2021-03-28T22:02:44.227+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "43 seconds",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106084",
+              "Release": "/api/Spaces-622/releases/Releases-85683",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1422595"
+            }
+          }
+        ],
+        "Environments-2585": [
+          {
+            "Id": "Deployments-106086",
+            "ProjectId": "Projects-4224",
+            "EnvironmentId": "Environments-2585",
+            "ReleaseId": "Releases-85683",
+            "DeploymentId": "Deployments-106086",
+            "TaskId": "ServerTasks-1422605",
+            "TenantId": null,
+            "ChannelId": "Channels-4946",
+            "ReleaseVersion": "2021.2.1033",
+            "Created": "2021-03-28T22:04:42.439+00:00",
+            "QueueTime": "2021-03-28T22:04:42.398+00:00",
+            "StartTime": "2021-03-28T22:04:43.113+00:00",
+            "CompletedTime": "2021-03-28T22:05:16.770+00:00",
+            "State": "Success",
+            "HasPendingInterruptions": false,
+            "HasWarningsOrErrors": false,
+            "ErrorMessage": "",
+            "Duration": "34 seconds",
+            "IsCurrent": false,
+            "IsPrevious": true,
+            "IsCompleted": true,
+            "Links": {
+              "Self": "/api/Spaces-622/deployments/Deployments-106086",
+              "Release": "/api/Spaces-622/releases/Releases-85683",
+              "Tenant": "/api/Spaces-622/tenants/",
+              "Task": "/api/tasks/ServerTasks-1422605"
+            }
+          }
+        ]
+      },
+      "NextDeployments": [],
+      "HasUnresolvedDefect": false,
+      "ReleaseRetentionPeriod": null,
+      "TentacleRetentionPeriod": null
+    }
+  ],
+  "Links": {}
+}

--- a/enthusiastic-promoter.ps1
+++ b/enthusiastic-promoter.ps1
@@ -203,6 +203,7 @@ function Add-PromotionCandidate {
 function Get-MostRecentReleaseDeployedToEnvironment($progression, $release, $environmentId) {
     return $progression.Releases `
            | Where-Object { $_.Release.ChannelId -eq $release.Release.ChannelId } `
+           | Where-Object { $false -eq [string]::IsNullOrEmpty($_.Deployments) }
            | where-object { (Get-AlreadyDeployedEnvironmentIds $_) -contains $environmentId } `
            | sort-object { New-Object Octopus.Versioning.Semver.SemanticVersion $_.Release.Version } -Descending `
            | Select-Object -First 1

--- a/enthusiastic-promotor.tests.ps1
+++ b/enthusiastic-promotor.tests.ps1
@@ -156,6 +156,21 @@ Describe 'Enthusiastic promoter' {
     $result | should -be $null
   }
 
+  It 'should skip releases in a channel that have not gone to any environment when checking most recent deploy to an environment'  {
+    Mock Test-PipelineBlocked { return $false }
+    Mock Get-CurrentDate { return [System.DateTime]::Parse("15/Apr/2021 10:00:00 AM") }
+    $progression = (Get-Content -Path "SampleData/sample8.json" -Raw) | ConvertFrom-Json
+    $channels = (Get-Content -Path "SampleData/sample8-channels.json" -Raw) | ConvertFrom-Json
+
+    $result = $((Get-PromotionCandidates $progression $channels).Values) | sort-object -property Version
+
+    $result.Count | should -be 1
+
+    $result[0].Version | Should -be "2021.1.6969"
+    $result[0].EnvironmentName | Should -be "Friends of Octopus"
+    $result[0].ChannelName | Should -be "Latest Release - 2021.1"
+  }
+
   It 'should not promote during weekend period' -TestCases @( # All written in AEST times
     @{ datetime = '20/Nov/2020 16:00:00'; shouldPromote = $false} #Friday 4pm
     @{ datetime = '20/Nov/2020 15:59:59'; shouldPromote = $true} #Friday 3:59pm


### PR DESCRIPTION
This was a very rare edge case as deployments were usually going straight to their first environment, but we ran into a bug on deploy today where they weren't automatically being sent to the first environment. 

The script was checking to see which release was the most recent, but when it did the `| where-object { (Get-AlreadyDeployedEnvironmentIds $_) -contains $environmentId }` it was including releases that haven't gone to any environments yet, so deployments was empty, and then in the `Get-AlreadyDeployedEnvironmentIds` function, it was doing `@($release.Deployments.PSObject.Properties.Name)` but failing because there was nothing in the deployment. Now we filter out deployments that haven't even been staged for their first environment yet. 

My approach may not be the best, but my powershell is limited Matt. Feel free to recommend a different appraoch when you're back :) 