### PR TITLE
Get more releases from progression api

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -17,18 +17,20 @@ jobs:
       with:
         timezoneLinux: "Australia/Brisbane"
 
-      - name: Install Pester
-        id: install-pester
-        run: Install-Module "Pester" -Force
-        shell: pwsh
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Run Pester Tests
-        id: pester-tests
-        run: |
-          Import-Module -Name "Pester"
-          $configuration = [PesterConfiguration]::Default
-          $configuration.Run.Exit = $true
-          $configuration.Run.PassThru = $true
-          Invoke-Pester -configuration $configuration
-        shell: pwsh
+    - name: Install Pester
+      id: install-pester
+      run: Install-Module "Pester" -Force
+      shell: pwsh
+
+    - name: Run Pester Tests
+      id: pester-tests
+      run: |
+        Import-Module -Name "Pester"
+        $configuration = [PesterConfiguration]::Default
+        $configuration.Run.Exit = $true
+        $configuration.Run.PassThru = $true
+        Invoke-Pester -configuration $configuration
+      shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+    - name: Set Timezone
+      uses: szenius/set-timezone@v1.0
+      with:
+        timezoneLinux: "Australia/Brisbane"
 
       - name: Install Pester
         id: install-pester

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -13,17 +13,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        
+
       - name: Install Pester
         id: install-pester
         run: Install-Module "Pester" -Force
         shell: pwsh
-       
+
       - name: Run Pester Tests
         id: pester-tests
         run: |
           Import-Module -Name "Pester"
           $configuration = [PesterConfiguration]::Default
           $configuration.Run.Exit = $true
+          $configuration.Run.PassThru = $true
           Invoke-Pester -configuration $configuration
         shell: pwsh

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
     - name: Set Timezone
       uses: szenius/set-timezone@v1.0
       with:
@@ -22,6 +21,7 @@ jobs:
         id: install-pester
         run: Install-Module "Pester" -Force
         shell: pwsh
+    - uses: actions/checkout@v2
 
       - name: Run Pester Tests
         id: pester-tests

--- a/enthusiastic-promoter.ps1
+++ b/enthusiastic-promoter.ps1
@@ -300,10 +300,10 @@ function Test-IsPromotionCandidate {
 
     if (Test-ReleaseInStabilizationPhase -channelId $release.Release.ChannelId -channels $channels) {
         Write-Host " - Release '$($release.Release.Version)' is in stabilization phase - allowing longer bake times"
-        $bakeTime = $waitTimeForEnvironmentLookup[$nextEnvironmentId].StabilizationPhaseBakeTime
+        $bakeTime = $waitTimeForEnvironmentLookup[$currentEnvironmentId].StabilizationPhaseBakeTime
     } else {
         Write-Host " - Release '$($release.Release.Version)' is not in stabilization phase - using shorter bake times"
-        $bakeTime = $waitTimeForEnvironmentLookup[$nextEnvironmentId].BakeTime
+        $bakeTime = $waitTimeForEnvironmentLookup[$currentEnvironmentId].BakeTime
     }
     Write-Host " - Calculated the bake time that releases should stay in environment '$currentEnvironmentName' before being promoted to '$nextEnvironmentName' to be $bakeTime."
 

--- a/enthusiastic-promoter.ps1
+++ b/enthusiastic-promoter.ps1
@@ -396,13 +396,14 @@ if (Test-Path variable:OctopusParameters) {
     $octofrontApiKey = $OctopusParameters["OctofrontSoftwareProblemsAuthToken"]
     $octofrontUrl = $OctopusParameters["OctofrontUrl"]
     $enthusiasticPromoterApiKey = $OctopusParameters["EnthusiasticPromoterApiKey"]
+    $octopusServerUrl = $OctopusParameters["Octopus.Web.ServerUri"]
 
     $candidates = Get-ChildItem -recurse -filter "Octopus.Versioning.dll"
     Add-Type -Path $candidates[-1].FullName
 
-    $progression = Get-FromApi "https://deploy.octopus.app/api/$spaceId/progression/$projectId"
-    $channels = Get-FromApi "https://deploy.octopus.app/api/$spaceId/projects/$projectId/channels"
-    $lifecycles = Get-FromApi "https://deploy.octopus.app/api/$spaceId/lifecycles/all"
+    $progression = Get-FromApi "$octopusServerUrl/api/$spaceId/progression/$($projectId)?releaseHistoryCount=100"
+    $channels = Get-FromApi "$octopusServerUrl/api/$spaceId/projects/$projectId/channels"
+    $lifecycles = Get-FromApi "$octopusServerUrl/api/$spaceId/lifecycles/all"
 
     $promotionCandidates = Get-PromotionCandidates -progression $progression -channels $channels -lifecycles $lifecycles
 


### PR DESCRIPTION
## Background
Given:

- As we're getting better at shipping releases, we're shipping multiple things per day.
- The enthusiastic promoter uses the progression api to find out what releases are worth looking at
- The progression api but as it's designed for dashboards, it only returns the last 3 releases for a given channel/environment(/tenant) combination.
- we allow a 24 hour bake time before promoting, to help find issues "in the real world"
- We were frequently facing an issue where more than 3 releases were shipped within 24 hours, meaning that the script would never find any valid releases to consider for promotion.

## Results
This PR uses the [new parameter added to the progression api](https://github.com/OctopusDeploy/OctopusDeploy/pull/8740) to request 100 releases per channel/environment.

It also fixes a bug where we were looking at the bake time for the next environment rather than the current environment

