### PR TITLE
Format dates better to avoid us/uk date ambuguity

### DIFF
--- a/enthusiastic-promoter.ps1
+++ b/enthusiastic-promoter.ps1
@@ -314,7 +314,7 @@ function Test-IsPromotionCandidate {
             Write-Host " - Release '$($release.Release.Version)' is valid for deployment, but '$($mostRecentReleaseDeployedToNextEnvironment.Release.Version)' was deployed recently ($ageOfLastDeployment ago, which is within the last $formattedMinimumTimeBetweenDeployments)."
             $currDate = Get-CurrentDate
             $retryTimeSpan = Format-TimeSpan $retryTime.Subtract($currDate)
-            Write-Host " - Will try again later after $($retryTime) (UTC) (in $retryTimeSpan)."
+            Write-Host " - Will try again later after $($retryTime.ToString("R")) (in $retryTimeSpan)."
         }
         return $nonCandidateResult
     }
@@ -332,11 +332,11 @@ function Test-IsPromotionCandidate {
     $deploymentsToCurrentEnvironment = Get-MostRecentDeploymentToEnvironment $release $currentEnvironmentId
     if (($null -ne $deploymentsToCurrentEnvironment) -and ($deploymentsToCurrentEnvironment.CompletedTime.Add($bakeTime) -gt (Get-CurrentDate))) {
         $ageOfLastDeployment = Format-Timespan (Get-CurrentDate).Subtract($deploymentsToCurrentEnvironment.CompletedTime)
-        Write-Host " - Completion time of last deployment to $currentEnvironmentName was $($deploymentsToCurrentEnvironment.CompletedTime) (UTC) ($ageOfLastDeployment ago)"
+        Write-Host " - Completion time of last deployment to $currentEnvironmentName was $($deploymentsToCurrentEnvironment.CompletedTime.ToString("R")) ($ageOfLastDeployment ago)"
         $retryTime = $deploymentsToCurrentEnvironment.CompletedTime.Add($bakeTime)
         $currDate = Get-CurrentDate
         $retryTimeSpan = Format-TimeSpan $retryTime.Subtract($currDate)
-        Write-Host " - This release is still baking. Will try again later after $($retryTime) (UTC) (in $retryTimeSpan)."
+        Write-Host " - This release is still baking. Will try again later after $($retryTime.ToString("R")) (in $retryTimeSpan)."
         return $nonCandidateResult
     }
     if (Test-IsWeekendAEST -and $waitTimeForEnvironmentLookup[$nextEnvironmentId].PreventDeploymentsOnWeekends) {
@@ -349,7 +349,7 @@ function Test-IsPromotionCandidate {
         # not sure this should ever happen
         Write-Warning " - Bake time was ignored as there was no deployments to the environment $currentEnvironmentName"
     } else {
-        Write-Host " - Completion time of last deployment to $currentEnvironmentName was $($deploymentsToCurrentEnvironment[0].CompletedTime) (UTC). Release has completed baking."
+        Write-Host " - Completion time of last deployment to $currentEnvironmentName was $($deploymentsToCurrentEnvironment[0].CompletedTime.ToString("R")). Release has completed baking."
     }
     Write-Host " - Checking Andon cord to see if release pipeline is blocked..."
     if (Test-PipelineBlocked $release) {


### PR DESCRIPTION
In this logging
```
Channel is Latest Release - 2021.1 
 - Current environment is 'Stable' 
 - Next environment is 'General Availablilty' 
 - Release '2021.1.7274' is not in stabilization phase - using shorter bake times 
 - Calculated the bake time that releases should stay in environment 'Stable' before being promoted to 'General Availablilty' to be 0h. 
 - Completion time of last deployment to Stable was 06/01/2021 08:02:18 (UTC). Release has completed baking. 
```

[We were unsure](https://octopusdeploy.slack.com/archives/C01HH8T16G3/p1622539588072700?thread_ts=1622537058.071100&cid=C01HH8T16G3) if the date was being treated as US or UK dates.

This PR formats the date as the RFC1123 pattern, ie `Mon, 15 Jun 2009 20:45:30 GMT`
