### PR TITLE
Update Github Action for correct Octo CLI version

### DIFF
--- a/.github/workflows/BuildTestPackagePush.yml
+++ b/.github/workflows/BuildTestPackagePush.yml
@@ -54,7 +54,7 @@ jobs:
         run: cp ./enthusiastic-promoter.ps1 ./packagesoutput/$OCTOPUS_PACKAGE_NAME
 
       - name: Install Octo CLI
-        uses: OctopusDeploy/install-octopus-cli-action@main
+        uses: OctopusDeploy/install-octopus-cli-action@v1
         with:
           version: latest
 


### PR DESCRIPTION
Updating github action to specify the correct Octo CLI version as per https://github.com/OctopusDeploy/install-octopus-cli-action#examples